### PR TITLE
Fix MemoryError in case of invalid checksum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [UNRELEASED]
+### Fixed
+- Fix MemoryError in case of invalid checksum ([#3](https://github.com/cbrnr/sleepecg/pull/3))
 
 ## [0.1.0] - 2021-07-29
 ### Added

--- a/sleepecg/io/utils.py
+++ b/sleepecg/io/utils.py
@@ -95,5 +95,5 @@ def download_file(
             raise RuntimeError(
                 f'Checksum mismatch for {target_filepath}:\n'
                 f'    {checksum!r} (expected)\n'
-                f'    {calculated_checksum!r} (calcuated)',
+                f'    {calculated_checksum!r} (calculated)',
             )

--- a/sleepecg/io/utils.py
+++ b/sleepecg/io/utils.py
@@ -55,7 +55,7 @@ def download_file(
     Download a single file from `url` to `target_filepath`.
 
     In case `checksum` and `checksum_type` are provided, the downloaded
-    file is verified.
+    file is verified. Raises a `RuntimeError` in case verification fails.
 
     Parameters
     ----------
@@ -69,12 +69,6 @@ def download_file(
         Type of the checksum, by default None.
     verbose : bool, optional
         If `True`, output information during download. By default False.
-
-    Raises
-    ------
-    RuntimeError
-        If the checksum verification fails.
-
     """
     if target_filepath.is_file():
         if checksum is not None and checksum_type is not None:

--- a/sleepecg/io/utils.py
+++ b/sleepecg/io/utils.py
@@ -72,7 +72,7 @@ def download_file(
     """
     if target_filepath.is_file():
         if checksum is not None and checksum_type is not None:
-            calculated_checksum = _calculate_checksum(target_filepath, checksum)
+            calculated_checksum = _calculate_checksum(target_filepath, checksum_type)
             if calculated_checksum == checksum:
                 if verbose:
                     print(f'Skipping {url}, already downloaded.')
@@ -90,7 +90,7 @@ def download_file(
         file.write(response.content)
 
     if checksum is not None and checksum_type is not None:
-        calculated_checksum = _calculate_checksum(target_filepath, checksum)
+        calculated_checksum = _calculate_checksum(target_filepath, checksum_type)
         if calculated_checksum != checksum:
             raise RuntimeError(
                 f'Checksum mismatch for {target_filepath}:\n'

--- a/sleepecg/io/utils.py
+++ b/sleepecg/io/utils.py
@@ -79,6 +79,12 @@ def download_file(
         Type of the checksum, by default None.
     verbose : bool, optional
         If `True`, output information during download. By default False.
+
+    Raises
+    ------
+    RuntimeError
+        If the checksum verification fails.
+
     """
     if checksum is not None and checksum_type is not None:
         if _verify_checksum(target_filepath, checksum, checksum_type):
@@ -99,5 +105,4 @@ def download_file(
 
     if checksum is not None and checksum_type is not None:
         if not _verify_checksum(target_filepath, checksum, checksum_type):
-            print(f'checksum verification failed for {target_filepath}, downloading again')
-            download_file(url, target_filepath, checksum, checksum_type)
+            raise RuntimeError(f'Checksum mismatch for {target_filepath}.')

--- a/sleepecg/io/utils.py
+++ b/sleepecg/io/utils.py
@@ -94,6 +94,6 @@ def download_file(
         if calculated_checksum != checksum:
             raise RuntimeError(
                 f'Checksum mismatch for {target_filepath}:\n'
-                f'    {checksum!r} (excpected)\n'
+                f'    {checksum!r} (expected)\n'
                 f'    {calculated_checksum!r} (calcuated)',
             )


### PR DESCRIPTION
`io.utils.download_file` calls itself to retry the download in case checksum verification fails. In case the "true" checksum is incorrect, this leads to an endless recursion stopped eventually by a `MemoryError`. I suggest to raise a `RuntimeError` instead of retrying. Alternatively, we could introduce a parameter to specify how many times the download should be retried.