### PR TITLE
Faster build+test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,11 +33,11 @@ jobs:
       CIBW_TEST_COMMAND: pytest {package}
       CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
       CIBW_MANYLINUX_I686_IMAGE: manylinux2014
-      CIBW_SKIP: cp37*
+      CIBW_BUILD: cp37*
       CIBW_ARCHS_MACOS: x86_64 arm64
 
     needs: [pre-commit]
-    name: Build wheels on ${{ matrix.os }}
+    name: Build cp37 wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -67,7 +67,7 @@ jobs:
       CIBW_ARCHS_MACOS: x86_64 arm64
 
     needs: [pre-commit]
-    name: Build wheels on ${{ matrix.os }}
+    name: Build all wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,8 +33,8 @@ jobs:
       CIBW_TEST_COMMAND: pytest {package}
       CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
       CIBW_MANYLINUX_I686_IMAGE: manylinux2014
-      CIBW_BUILD: cp37*
       CIBW_ARCHS_MACOS: x86_64 arm64
+      CIBW_BUILD: cp37*
 
     needs: [pre-commit]
     name: Build cp37 wheels on ${{ matrix.os }}
@@ -63,8 +63,8 @@ jobs:
       CIBW_TEST_COMMAND: pytest {package}
       CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
       CIBW_MANYLINUX_I686_IMAGE: manylinux2014
-      CIBW_SKIP: pp*
       CIBW_ARCHS_MACOS: x86_64 arm64
+      CIBW_SKIP: pp*
 
     needs: [pre-commit]
     name: Build all wheels on ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,8 @@ env:
   CIBW_TEST_COMMAND: pytest {package}
   CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
   CIBW_MANYLINUX_I686_IMAGE: manylinux2014
-  CIBW_SKIP: pp*
   CIBW_ARCHS_MACOS: x86_64 arm64
+  CIBW_SKIP: pp*
 
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,15 +14,6 @@ concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  CIBW_TEST_REQUIRES: pytest
-  CIBW_TEST_EXTRAS: full
-  CIBW_TEST_COMMAND: pytest {package}
-  CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-  CIBW_MANYLINUX_I686_IMAGE: manylinux2014
-  CIBW_SKIP: pp*
-  CIBW_ARCHS_MACOS: x86_64 arm64
-
 
 jobs:
   pre-commit:
@@ -34,7 +25,47 @@ jobs:
     - uses: pre-commit/action@v2.0.3
 
 
-  build_wheels:
+  build_wheels_37:
+    if: "!contains(github.event.head_commit.message, '[buildall]')"
+    env:
+      CIBW_TEST_REQUIRES: pytest
+      CIBW_TEST_EXTRAS: full
+      CIBW_TEST_COMMAND: pytest {package}
+      CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+      CIBW_MANYLINUX_I686_IMAGE: manylinux2014
+      CIBW_SKIP: cp37*
+      CIBW_ARCHS_MACOS: x86_64 arm64
+
+    needs: [pre-commit]
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019, macos-10.15]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v1.12.0
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl
+
+
+  build_wheels_all:
+    if: "contains(github.event.head_commit.message, '[buildall]')"
+    env:
+      CIBW_TEST_REQUIRES: pytest
+      CIBW_TEST_EXTRAS: full
+      CIBW_TEST_COMMAND: pytest {package}
+      CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+      CIBW_MANYLINUX_I686_IMAGE: manylinux2014
+      CIBW_SKIP: pp*
+      CIBW_ARCHS_MACOS: x86_64 arm64
+
     needs: [pre-commit]
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,88 +10,42 @@ on:
   workflow_dispatch:
     # allow manual runs on branches without a PR
 
-concurrency:
-  group: ${{ github.ref }}
-  cancel-in-progress: true
+
+env:
+  CIBW_TEST_REQUIRES: pytest
+  CIBW_TEST_EXTRAS: full
+  CIBW_TEST_COMMAND: pytest {package}
+  CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+  CIBW_MANYLINUX_I686_IMAGE: manylinux2014
+  CIBW_SKIP: pp*
+  CIBW_ARCHS_MACOS: x86_64 arm64
 
 
 jobs:
-  debug:
-    env:
-      commitmsg: $(git log --format=%B -n 1 ${{github.pull_request.head.sha}})
+  pre-commit:
+    name: Pre-commit checks
     runs-on: ubuntu-latest
     steps:
-      - name: checkout
-        uses: actions/checkout@v2
-      - name: get commit message
-        run: |
-            echo Commit MSG = ${{ env.commitmsg }}
-  # pre-commit:
-  #   name: Pre-commit checks
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - uses: actions/setup-python@v2
-  #   - uses: pre-commit/action@v2.0.3
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - uses: pre-commit/action@v2.0.3
 
 
-  # build_wheels_37:
-  #   if: "!contains(github.event.head_commit.message, '[buildall]')"
-  #   env:
-  #     CIBW_TEST_REQUIRES: pytest
-  #     CIBW_TEST_EXTRAS: full
-  #     CIBW_TEST_COMMAND: pytest {package}
-  #     CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-  #     CIBW_MANYLINUX_I686_IMAGE: manylinux2014
-  #     CIBW_ARCHS_MACOS: x86_64 arm64
-  #     CIBW_BUILD: cp37*
+  build_wheels:
+    needs: [pre-commit]
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
 
-  #   needs: [pre-commit]
-  #   name: Build cp37 wheels on ${{ matrix.os }}
-  #   runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019, macos-10.15]
 
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-20.04, windows-2019, macos-10.15]
+    steps:
+      - uses: actions/checkout@v2
 
-  #   steps:
-  #     - run: |
-  #         echo ${{ github.event.head_commit.message }}
-  #     - uses: actions/checkout@v2
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v1.12.0
 
-  #     - name: Build wheels
-  #       uses: pypa/cibuildwheel@v1.12.0
-
-  #     - uses: actions/upload-artifact@v2
-  #       with:
-  #         path: ./wheelhouse/*.whl
-
-
-  # build_wheels_all:
-  #   if: "contains(github.event.head_commit.message, '[buildall]')"
-  #   env:
-  #     CIBW_TEST_REQUIRES: pytest
-  #     CIBW_TEST_EXTRAS: full
-  #     CIBW_TEST_COMMAND: pytest {package}
-  #     CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-  #     CIBW_MANYLINUX_I686_IMAGE: manylinux2014
-  #     CIBW_ARCHS_MACOS: x86_64 arm64
-  #     CIBW_SKIP: pp*
-
-  #   needs: [pre-commit]
-  #   name: Build all wheels on ${{ matrix.os }}
-  #   runs-on: ${{ matrix.os }}
-
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-20.04, windows-2019, macos-10.15]
-
-  #   steps:
-  #     - uses: actions/checkout@v2
-
-  #     - name: Build wheels
-  #       uses: pypa/cibuildwheel@v1.12.0
-
-  #     - uses: actions/upload-artifact@v2
-  #       with:
-  #         path: ./wheelhouse/*.whl
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   debug:
     env:
-      commitmsg: $(git log --format=%B -n 1 ${{github.event.after}})
+      commitmsg: $(git log --format=%B -n 1 ${{pull_request.head.sha}})
     runs-on: ubuntu-latest
     steps:
       - name: checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: |
-          echo ${{ github.event.head_commit.message }}
+          echo "${{ github.event.head_commit.message }}"
 
   # pre-commit:
   #   name: Pre-commit checks

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,15 +16,13 @@ concurrency:
 
 
 jobs:
-  env:
-    commitmsg: ${{ github.event.head_commit.message }}
   runs-on: ubuntu-latest
   steps:
-    - name: checkout
-      uses: actions/checkout@v2
-    - name: get commit message
-      run: |
-          echo Commit MSG = ${{ env.commitmsg }}
+  - name: checkout
+    uses: actions/checkout@v2
+  - name: get commit message
+    run: |
+        echo Commit MSG = ${{ github.event.head_commit.message }}
   # pre-commit:
   #   name: Pre-commit checks
   #   runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,70 +16,79 @@ concurrency:
 
 
 jobs:
-  pre-commit:
-    name: Pre-commit checks
+  debug:
+    name: Debug
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-    - uses: pre-commit/action@v2.0.3
+      - run: |
+          echo ${{ github.event.head_commit.message }}
+
+  # pre-commit:
+  #   name: Pre-commit checks
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - uses: actions/setup-python@v2
+  #   - uses: pre-commit/action@v2.0.3
 
 
-  build_wheels_37:
-    if: "!contains(github.event.head_commit.message, '[buildall]')"
-    env:
-      CIBW_TEST_REQUIRES: pytest
-      CIBW_TEST_EXTRAS: full
-      CIBW_TEST_COMMAND: pytest {package}
-      CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-      CIBW_MANYLINUX_I686_IMAGE: manylinux2014
-      CIBW_ARCHS_MACOS: x86_64 arm64
-      CIBW_BUILD: cp37*
+  # build_wheels_37:
+  #   if: "!contains(github.event.head_commit.message, '[buildall]')"
+  #   env:
+  #     CIBW_TEST_REQUIRES: pytest
+  #     CIBW_TEST_EXTRAS: full
+  #     CIBW_TEST_COMMAND: pytest {package}
+  #     CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+  #     CIBW_MANYLINUX_I686_IMAGE: manylinux2014
+  #     CIBW_ARCHS_MACOS: x86_64 arm64
+  #     CIBW_BUILD: cp37*
 
-    needs: [pre-commit]
-    name: Build cp37 wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+  #   needs: [pre-commit]
+  #   name: Build cp37 wheels on ${{ matrix.os }}
+  #   runs-on: ${{ matrix.os }}
 
-    strategy:
-      matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-20.04, windows-2019, macos-10.15]
 
-    steps:
-      - uses: actions/checkout@v2
+  #   steps:
+  #     - run: |
+  #         echo ${{ github.event.head_commit.message }}
+  #     - uses: actions/checkout@v2
 
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v1.12.0
+  #     - name: Build wheels
+  #       uses: pypa/cibuildwheel@v1.12.0
 
-      - uses: actions/upload-artifact@v2
-        with:
-          path: ./wheelhouse/*.whl
+  #     - uses: actions/upload-artifact@v2
+  #       with:
+  #         path: ./wheelhouse/*.whl
 
 
-  build_wheels_all:
-    if: "contains(github.event.head_commit.message, '[buildall]')"
-    env:
-      CIBW_TEST_REQUIRES: pytest
-      CIBW_TEST_EXTRAS: full
-      CIBW_TEST_COMMAND: pytest {package}
-      CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-      CIBW_MANYLINUX_I686_IMAGE: manylinux2014
-      CIBW_ARCHS_MACOS: x86_64 arm64
-      CIBW_SKIP: pp*
+  # build_wheels_all:
+  #   if: "contains(github.event.head_commit.message, '[buildall]')"
+  #   env:
+  #     CIBW_TEST_REQUIRES: pytest
+  #     CIBW_TEST_EXTRAS: full
+  #     CIBW_TEST_COMMAND: pytest {package}
+  #     CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+  #     CIBW_MANYLINUX_I686_IMAGE: manylinux2014
+  #     CIBW_ARCHS_MACOS: x86_64 arm64
+  #     CIBW_SKIP: pp*
 
-    needs: [pre-commit]
-    name: Build all wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+  #   needs: [pre-commit]
+  #   name: Build all wheels on ${{ matrix.os }}
+  #   runs-on: ${{ matrix.os }}
 
-    strategy:
-      matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-20.04, windows-2019, macos-10.15]
 
-    steps:
-      - uses: actions/checkout@v2
+  #   steps:
+  #     - uses: actions/checkout@v2
 
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v1.12.0
+  #     - name: Build wheels
+  #       uses: pypa/cibuildwheel@v1.12.0
 
-      - uses: actions/upload-artifact@v2
-        with:
-          path: ./wheelhouse/*.whl
+  #     - uses: actions/upload-artifact@v2
+  #       with:
+  #         path: ./wheelhouse/*.whl

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,13 +16,16 @@ concurrency:
 
 
 jobs:
-  runs-on: ubuntu-latest
-  steps:
-  - name: checkout
-    uses: actions/checkout@v2
-  - name: get commit message
-    run: |
-        echo Commit MSG = ${{ github.event.head_commit.message }}
+  debug:
+    env:
+      commitmsg: ${{ github.event.head_commit.message }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: get commit message
+        run: |
+            echo Commit MSG = ${{ env.commitmsg }}
   # pre-commit:
   #   name: Pre-commit checks
   #   runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,8 @@ env:
   CIBW_TEST_COMMAND: pytest {package}
   CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
   CIBW_MANYLINUX_I686_IMAGE: manylinux2014
-  CIBW_ARCHS_MACOS: x86_64 arm64
   CIBW_SKIP: pp*
+  CIBW_ARCHS_MACOS: x86_64 arm64
 
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ on:
   workflow_dispatch:
     # allow manual runs on branches without a PR
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CIBW_TEST_REQUIRES: pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,13 +16,15 @@ concurrency:
 
 
 jobs:
-  debug:
-    name: Debug
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          echo "${{ github.event.head_commit.message }}"
-
+  env:
+    commitmsg: ${{ github.event.head_commit.message }}
+  runs-on: ubuntu-latest
+  steps:
+    - name: checkout
+      uses: actions/checkout@v2
+    - name: get commit message
+      run: |
+          echo Commit MSG = ${{ env.commitmsg }}
   # pre-commit:
   #   name: Pre-commit checks
   #   runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   debug:
     env:
-      commitmsg: $(git log --format=%B -n 1 ${{pull_request.head.sha}})
+      commitmsg: $(git log --format=%B -n 1 ${{github.pull_request.head.sha}})
     runs-on: ubuntu-latest
     steps:
       - name: checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   debug:
     env:
-      commitmsg: ${{ github.event.head_commit.message }}
+      commitmsg: $(git log --format=%B -n 1 ${{github.event.after}})
     runs-on: ubuntu-latest
     steps:
       - name: checkout


### PR DESCRIPTION
The build+test workflow (in `test.yml`) is triggered on PRs. Currently, it builds wheels for cp37, cp38 and cp39 for each platform. To shorten workflow runtime (and save runner minutes), I'd suggest the following steps:
- [x] cancel previous in-progress workflows using concurrency groups
- [ ] ~~build only cp37 (the minimum required python version) wheels (but keep building+testing all wheels in the release-workflow)~~
- [ ] use cached pip package files (not sure how this works with cibuildwheel yet)