### PR TITLE
Fix incorrect names in heartbeat_detection

### DIFF
--- a/sleepecg/_heartbeat_detection.c
+++ b/sleepecg/_heartbeat_detection.c
@@ -63,7 +63,7 @@ static PyObject *_squared_moving_integration(PyObject *self,
                                                   NPY_ANYORDER,
                                                   NULL,
                                                   0);
-    double *beat_mask = (double *)PyArray_DATA((PyArrayObject *)output_array);
+    double *output = (double *)PyArray_DATA((PyArrayObject *)output_array);
 
     // create a circular buffer to store values inside integration window
     double *integration_buffer = (double *)calloc(window_length,
@@ -89,7 +89,7 @@ static PyObject *_squared_moving_integration(PyObject *self,
 
     for (int i = window_length_half; i < signal_len; ++i)
     {
-        beat_mask[i - window_length_half] = sum; // write to 'window center'
+        output[i - window_length_half] = sum; // write to 'window center'
         sum -= integration_buffer[i % window_length];
         square = input[i] * input[i];
         integration_buffer[i % window_length] = square;
@@ -101,7 +101,7 @@ static PyObject *_squared_moving_integration(PyObject *self,
     // filled
     for (int i = (int)signal_len; i < signal_len + window_length_half; ++i)
     {
-        beat_mask[i - window_length_half] = sum;
+        output[i - window_length_half] = sum;
         sum -= integration_buffer[i % window_length];
     }
 

--- a/sleepecg/heartbeat_detection.py
+++ b/sleepecg/heartbeat_detection.py
@@ -92,7 +92,7 @@ def detect_heartbeats(ecg: np.ndarray, fs: float) -> np.ndarray:
     signal_start = np.where(np.diff(np.signbit(filtered_ecg[:int(2 * fs)])))[0][0] + 1
     filtered_ecg[:signal_start] = 0
 
-    # scipy.signal.sosfilt returns an array with negative strides. Both
+    # scipy.signal.sosfiltfilt returns an array with negative strides. Both
     # `np.correlate` and `_thresholding` require contiguity, so ensuring
     # this here once reduces total runtime.
     filtered_ecg = np.ascontiguousarray(filtered_ecg)


### PR DESCRIPTION
Found two naming mistakes:
- `heartbeat_detection.py:95` mentions `scipy.signal.sosfilt`, although `sosfilfilt` is used (and causes the described issue)
- in `_heartbeat_detection.c:_squared_moving_integration` the pointer to the output array's data is called `beat_mask` (copy-paste error from `_thresholding`)