### PR TITLE
Provide API reference on readthedocs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ dist
 *.egg-info
 *.pyd
 *.so
-doc/_autosummary/
+doc/source/generated/

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist
 *.egg-info
 *.pyd
 *.so
+doc/_autosummary/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,4 @@ repos:
   rev: 6.1.1
   hooks:
   - id: pydocstyle
+    files: ^sleepecg/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ![Py Version](https://img.shields.io/pypi/pyversions/sleepecg.svg?logo=python&logoColor=white)
 [![PyPI Version](https://img.shields.io/pypi/v/sleepecg)](https://pypi.org/project/sleepecg/)
+[![Docs](https://readthedocs.org/projects/sleepecg/badge/?version=latest)](https://sleepecg.readthedocs.io/en/latest/generated/sleepecg.html)
 
 # SleepECG
 This package provides tools for sleep stage classification when [EEG](https://en.wikipedia.org/wiki/Electroencephalography) signals are not available. Based only on [ECG](https://en.wikipedia.org/wiki/Electrocardiography) (and to a lesser extent also movement data), SleepECG provides a functional interface for

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,8 +1,3 @@
-# Minimal makefile for Sphinx documentation
-#
-
-# You can set these variables from the command line, and also
-# from the environment for the first two.
 SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -1,0 +1,4 @@
+m2r2
+numpydoc
+pydata_sphinx_theme
+sphinx

--- a/doc/source/_templates/custom-class-template.rst
+++ b/doc/source/_templates/custom-class-template.rst
@@ -1,0 +1,34 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+   :members:
+   :show-inheritance:
+   :inherited-members:
+   :special-members: __call__, __add__, __mul__
+
+   {% block methods %}
+   {% if methods %}
+   .. rubric:: {{ _('Methods') }}
+
+   .. autosummary::
+      :nosignatures:
+   {% for item in methods %}
+      {%- if not item.startswith('_') %}
+      ~{{ name }}.{{ item }}
+      {%- endif -%}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: {{ _('Attributes') }}
+
+   .. autosummary::
+   {% for item in attributes %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}

--- a/doc/source/_templates/custom-module-template.rst
+++ b/doc/source/_templates/custom-module-template.rst
@@ -1,0 +1,66 @@
+{{ fullname | escape | underline}}
+
+.. automodule:: {{ fullname }}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: Module attributes
+
+   .. autosummary::
+      :toctree:
+   {% for item in attributes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block functions %}
+   {% if functions %}
+   .. rubric:: {{ _('Functions') }}
+
+   .. autosummary::
+      :toctree:
+      :nosignatures:
+   {% for item in functions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block classes %}
+   {% if classes %}
+   .. rubric:: {{ _('Classes') }}
+
+   .. autosummary::
+      :toctree:
+      :template: custom-class-template.rst
+      :nosignatures:
+   {% for item in classes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block exceptions %}
+   {% if exceptions %}
+   .. rubric:: {{ _('Exceptions') }}
+
+   .. autosummary::
+      :toctree:
+   {% for item in exceptions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+{% block modules %}
+{% if modules %}
+.. autosummary::
+   :toctree:
+   :template: custom-module-template.rst
+   :recursive:
+{% for item in modules %}
+   {{ item }}
+{%- endfor %}
+{% endif %}
+{% endblock %}

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -1,0 +1,13 @@
+..
+   From https://github.com/JamesALeedham/Sphinx-Autosummary-Recursion
+   DO NOT DELETE THIS FILE! It contains the all-important `.. autosummary::` directive with `:recursive:` option, without
+   which API documentation wouldn't get extracted from docstrings by the `sphinx.ext.autosummary` engine. It is hidden
+   (not declared in any toctree) to remove an unnecessary intermediate page; index.rst instead points directly to the
+   package page. DO NOT REMOVE THIS FILE!
+
+.. autosummary::
+   :toctree: generated
+   :template: custom-module-template.rst
+   :recursive:
+
+   sleepecg

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -34,6 +34,8 @@ intersphinx_mapping = {
     'scipy': ('https://scipy.github.io/devdocs', None),
 }
 
+default_role = 'code'
+
 autoclass_content = 'class'
 autodoc_inherit_docstrings = False
 autodoc_mock_imports = ['scipy', 'tqdm']

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,0 +1,123 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a
+# full list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+import inspect
+import os
+import re
+import sys
+
+import sleepecg
+
+# -- Project information --------------------------------------------------
+project = 'SleepECG'
+author = 'Florian Hofer'
+copyright = '2021, SleepECG Developers'
+version = sleepecg.__version__
+
+# -- General configuration ------------------------------------------------
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.linkcode',
+    'numpydoc',
+    'm2r2',
+]
+
+source_suffix = ['.rst', '.md']
+
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'numpy': ('https://numpy.org/devdocs', None),
+    'scipy': ('https://scipy.github.io/devdocs', None),
+}
+
+autoclass_content = 'class'
+autodoc_inherit_docstrings = False
+autodoc_mock_imports = ['scipy', 'tqdm']
+autodoc_typehints = 'none'
+autosummary_generate = True
+html_show_sourcelink = False
+
+numpydoc_class_members_toctree = False
+numpydoc_show_class_members = False
+numpydoc_show_inherited_class_members = False
+numpydoc_xref_param_type = True
+
+templates_path = ['_templates']
+
+# -- Options for HTML output ----------------------------------------------
+html_theme = 'pydata_sphinx_theme'
+html_theme_options = {
+    'github_url': 'https://github.com/cbrnr/sleepecg',
+    'show_prev_next': False,
+}
+
+
+def linkcode_resolve(domain, info):
+    """
+    Determine the URL corresponding to Python object.
+
+    Adapted from SciPy (doc/source/conf.py).
+    """
+    if domain != 'py':
+        return None
+
+    modname = info['module']
+    fullname = info['fullname']
+
+    submod = sys.modules.get(modname)
+    if submod is None:
+        return None
+
+    obj = submod
+    for part in fullname.split('.'):
+        try:
+            obj = getattr(obj, part)
+        except Exception:
+            return None
+
+    try:
+        fn = inspect.getsourcefile(obj)
+    except Exception:
+        fn = None
+    if not fn:
+        try:
+            fn = inspect.getsourcefile(sys.modules[obj.__module__])
+        except Exception:
+            fn = None
+    if not fn:
+        return None
+
+    try:
+        source, lineno = inspect.getsourcelines(obj)
+    except Exception:
+        lineno = None
+
+    if lineno:
+        linespec = '#L%d-L%d' % (lineno, lineno + len(source) - 1)
+    else:
+        linespec = ''
+
+    startdir = os.path.abspath('../../sleepecg')
+    fn = os.path.relpath(fn, start=startdir).replace(os.path.sep, '/')
+
+    if fn.startswith('sleepecg/'):
+        m = re.match(r'^.*dev0\+([a-f0-9]+)$', version)
+        if m:
+            return 'https://github.com/cbrnr/sleepecg/blob/%s/%s%s' % (
+                m.group(1), fn, linespec,
+            )
+        elif 'dev' in version:
+            return 'https://github.com/cbrnr/sleepecg/blob/main/%s%s' % (
+                fn, linespec,
+            )
+        else:
+            return 'https://github.com/cbrnr/sleepecg/blob/v%s/%s%s' % (
+                version, fn, linespec,
+            )
+    else:
+        return None

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,0 +1,11 @@
+..
+   Note: From https://github.com/JamesALeedham/Sphinx-Autosummary-Recursion
+
+.. toctree::
+   :hidden:
+
+   Home Page <self>
+   API reference <generated/sleepecg>
+
+
+.. mdinclude:: ../../README.md

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,16 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+sphinx:
+  configuration: doc/source/conf.py
+
+python:
+  version: 3.7
+  system_packages: true
+  install:
+  - requirements: doc/requirements-doc.txt
+  - method: setuptools
+    path: "."

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,4 +61,3 @@ include_trailing_comma = true
 
 [pydocstyle]
 convention = numpy
-add-ignore = D100,D104

--- a/sleepecg/__init__.py
+++ b/sleepecg/__init__.py
@@ -1,4 +1,4 @@
-"""A toolbox for sleep stage classification using ECG data."""
+"""A package for sleep stage classification using ECG data."""
 
 from . import io
 from .heartbeat_detection import compare_heartbeats, detect_heartbeats, rri_similarity

--- a/sleepecg/__init__.py
+++ b/sleepecg/__init__.py
@@ -1,3 +1,5 @@
+"""A toolbox for sleep stage classification using ECG data."""
+
 from . import io
 from .heartbeat_detection import compare_heartbeats, detect_heartbeats, rri_similarity
 

--- a/sleepecg/heartbeat_detection.py
+++ b/sleepecg/heartbeat_detection.py
@@ -2,6 +2,8 @@
 #
 # License: BSD (3-clause)
 
+"""Heartbeat detection and detector evaluation."""
+
 from typing import NamedTuple
 
 import numpy as np

--- a/sleepecg/heartbeat_detection.py
+++ b/sleepecg/heartbeat_detection.py
@@ -139,7 +139,7 @@ def compare_heartbeats(
         Annotated heartbeat indices.
     max_distance : int, optional
         Maximum distance between indices to consider as the same peak, by
-        default 0.
+        default `0`.
 
     Returns
     -------

--- a/sleepecg/io/__init__.py
+++ b/sleepecg/io/__init__.py
@@ -1,3 +1,5 @@
+"""Functions for downloading and reading datasets."""
+
 from .ecg_readers import read_gudb, read_mitbih
 from .nsrr_api import download_nsrr_files, set_nsrr_token
 

--- a/sleepecg/io/ecg_readers.py
+++ b/sleepecg/io/ecg_readers.py
@@ -2,7 +2,7 @@
 #
 # License: BSD (3-clause)
 
-"""Functions for reading datasets containing ECG data and beat annotations."""
+"""Functions for reading datasets containing ECG and beat annotations."""
 
 from dataclasses import dataclass
 from pathlib import Path

--- a/sleepecg/io/ecg_readers.py
+++ b/sleepecg/io/ecg_readers.py
@@ -58,7 +58,7 @@ def read_mitbih(
 
     Parameters
     ----------
-    data_dir : Union[str, Path]
+    data_dir : str | pathlib.Path
         Directory where all datasets are stored.
     db_slug : str
         Short identifier of a database, e.g. 'mitdb'.
@@ -121,7 +121,7 @@ def read_gudb(data_dir: Union[str, Path], offline: bool = False) -> Iterator[ECG
 
     Parameters
     ----------
-    data_dir : Union[str, Path]
+    data_dir : str | pathlib.Path
         Directory where all datasets are stored.
     offline : bool, optional
         If `True`, only local files will be used (i.e. no files will be

--- a/sleepecg/io/ecg_readers.py
+++ b/sleepecg/io/ecg_readers.py
@@ -34,17 +34,17 @@ class ECGRecord:
         The sampling frequency.
     annotation : np.ndarray
         Indices of annotated heartbeats.
-    lead : Optional[str]
-        Which ECG lead the signal was recorded from.
-    id : Optional[str]
-        The record's ID.
+    lead : str, optional
+        Which ECG lead the signal was recorded from, by default `None`.
+    id : str, optional
+        The record's ID, by default `None`.
     """
 
     ecg: np.ndarray
     fs: float
     annotation: np.ndarray
-    lead: Optional[str] = ''
-    id: Optional[str] = ''
+    lead: Optional[str] = None
+    id: Optional[str] = None
 
 
 def read_mitbih(
@@ -56,25 +56,25 @@ def read_mitbih(
     """
     Lazily reads records from MIT-BIH datasets (e.g. MITDB, LTDB).
 
-    Required files are downloaded if not present in '<data_dir>/<db_slug>'.
+    Required files are downloaded if not present in `<data_dir>/<db_slug>`.
 
     Parameters
     ----------
     data_dir : str | pathlib.Path
         Directory where all datasets are stored.
     db_slug : str
-        Short identifier of a database, e.g. 'mitdb'.
+        Short identifier of a database, e.g. `'mitdb'`.
     records_pattern : str, optional
-        Glob-like pattern to select record IDs, by default '*'.
+        Glob-like pattern to select record IDs, by default `'*'`.
     offline : bool, optional
         If `True`, only local files will be used (i.e. no files will be
-        downloaded), by default False.
+        downloaded), by default `False`.
 
     Yields
     ------
     Iterator[ECGRecord]
-        Each element in the generator is of type ECGRecord and contains the
-        ECG signal (`.ecg`), sampling frequency (`.fs`), annotated beat
+        Each element in the generator is of type `ECGRecord` and contains
+        the ECG signal (`.ecg`), sampling frequency (`.fs`), annotated beat
         indices (`.annotations`), `.lead`, and `.id`.
     """
     import wfdb
@@ -119,7 +119,7 @@ def read_gudb(data_dir: Union[str, Path], offline: bool = False) -> Iterator[ECG
     """
     Lazily reads records from GUDB (https://berndporr.github.io/ECG-GUDB/).
 
-    Required files are downloaded if not present in '<data_dir>/gudb'.
+    Required files are downloaded if not present in `'<data_dir>/gudb'`.
 
     Parameters
     ----------
@@ -127,13 +127,13 @@ def read_gudb(data_dir: Union[str, Path], offline: bool = False) -> Iterator[ECG
         Directory where all datasets are stored.
     offline : bool, optional
         If `True`, only local files will be used (i.e. no files will be
-        downloaded), by default False.
+        downloaded), by default `False`.
 
     Yields
     ------
     Iterator[ECGRecord]
-        Each element in the generator is of type ECGRecord and contains the
-        ECG signal (`.ecg`), sampling frequency (`.fs`), annotated beat
+        Each element in the generator is of type `ECGRecord` and contains
+        the ECG signal (`.ecg`), sampling frequency (`.fs`), annotated beat
         indices (`.annotations`), `.lead`, and `.id`.
     """
     import pandas as pd

--- a/sleepecg/io/ecg_readers.py
+++ b/sleepecg/io/ecg_readers.py
@@ -2,6 +2,8 @@
 #
 # License: BSD (3-clause)
 
+"""Functions to read datasets containing ECG data and beat annotations."""
+
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterator, Optional, Union

--- a/sleepecg/io/ecg_readers.py
+++ b/sleepecg/io/ecg_readers.py
@@ -2,7 +2,7 @@
 #
 # License: BSD (3-clause)
 
-"""Functions to read datasets containing ECG data and beat annotations."""
+"""Functions for reading datasets containing ECG data and beat annotations."""
 
 from dataclasses import dataclass
 from pathlib import Path

--- a/sleepecg/io/nsrr_api.py
+++ b/sleepecg/io/nsrr_api.py
@@ -97,7 +97,7 @@ def list_nsrr_files(
         root folder).
     pattern : str, optional
         Glob-like pattern to select files (only applied to the basename,
-        not the dirname!), by default `'*'`.
+        not the dirname), by default `'*'`.
     shallow : bool, optional
         If `True`, only search in the given subfolder (i.e. no recursion),
         by default `False`.
@@ -105,9 +105,9 @@ def list_nsrr_files(
     Returns
     -------
     list[tuple[str, str]]
-        A list of tuples `(<filename>, <checksum>)`. `<filename>` is the
-        full filename (i.e. dirname and basename), `<checksum>` the
-        md5-checksum.
+        A list of tuples `(<filename>, <checksum>)`; `<filename>` is the
+        full filename (i.e. dirname and basename) and `<checksum>` the
+        MD5 checksum.
     """
     api_url = f'https://sleepdata.org/api/v1/datasets/{db_slug}/files.json'
 
@@ -150,7 +150,7 @@ def download_nsrr_files(
         root folder).
     pattern : str, optional
         Glob-like pattern to select files (only applied to the basename,
-        not the dirname!), by default `'*'`.
+        not the dirname), by default `'*'`.
     shallow : bool, optional
         If `True`, only download files in the given subfolder (i.e. no
         recursion), by default `False`.

--- a/sleepecg/io/nsrr_api.py
+++ b/sleepecg/io/nsrr_api.py
@@ -2,6 +2,8 @@
 #
 # License: BSD (3-clause)
 
+"""Interface for listing and downloading NSRR (sleepdata.org) data."""
+
 from fnmatch import fnmatch
 from json.decoder import JSONDecodeError
 from pathlib import Path
@@ -60,7 +62,7 @@ def get_nsrr_download_url(db_slug: str) -> str:
     Parameters
     ----------
     db_slug : str
-        Short identifier of a database, e.g. 'mesa'.
+        Short identifier of a database, e.g. `'mesa'`.
 
     Returns
     -------
@@ -89,22 +91,23 @@ def list_nsrr_files(
     Parameters
     ----------
     db_slug : str
-        Short identifier of a database, e.g. 'mesa'.
+        Short identifier of a database, e.g. `'mesa'`.
     subfolder : str, optional
-        The folder at which to start the search, by default '' (i.e. the
+        The folder at which to start the search, by default `''` (i.e. the
         root folder).
     pattern : str, optional
         Glob-like pattern to select files (only applied to the basename,
-        not the dirname!), by default '*'.
+        not the dirname!), by default `'*'`.
     shallow : bool, optional
-        If True, only search in the given subfolder (i.e. no recursion), by
-        default False.
+        If `True`, only search in the given subfolder (i.e. no recursion),
+        by default `False`.
 
     Returns
     -------
-    List[Tuple[str, str]]
-        A list of tuples (<filename>, <checksum>). <filename> is the full
-        filename (i.e. dirname and basename), <checksum> the md5-checksum.
+    list[tuple[str, str]]
+        A list of tuples `(<filename>, <checksum>)`. `<filename>` is the
+        full filename (i.e. dirname and basename), `<checksum>` the
+        md5-checksum.
     """
     api_url = f'https://sleepdata.org/api/v1/datasets/{db_slug}/files.json'
 
@@ -141,18 +144,18 @@ def download_nsrr_files(
     Parameters
     ----------
     db_slug : str
-        Short identifier of a database, e.g. 'mesa'.
+        Short identifier of a database, e.g. `'mesa'`.
     subfolder : str, optional
-        The folder at which to start the search, by default '' (i.e. the
+        The folder at which to start the search, by default `''` (i.e. the
         root folder).
     pattern : str, optional
         Glob-like pattern to select files (only applied to the basename,
-        not the dirname!), by default '*'.
+        not the dirname!), by default `'*'`.
     shallow : bool, optional
-        If True, only download files in the given subfolder (i.e. no
-        recursion), by default False.
-    data_dir : Union[str, Path], optional
-        Directory where all datasets are stored, by default '.'.
+        If `True`, only download files in the given subfolder (i.e. no
+        recursion), by default `False`.
+    data_dir : str | pathlib.Path, optional
+        Directory where all datasets are stored, by default `'.'`.
     """
     db_dir = Path(data_dir) / db_slug
 

--- a/sleepecg/io/physionet_api.py
+++ b/sleepecg/io/physionet_api.py
@@ -34,19 +34,19 @@ def list_physionet_records(
 
     Parameters
     ----------
-    data_dir : Path
+    data_dir : pathlib.Path
         Directory where all datasets are stored. Required to download the
         RECORDS-file.
     db_slug : str
         Short identifier of a database, e.g. 'mitdb'.
-    db_version : Optional[str], optional
+    db_version : str, optional
         Version of the database, by default '1.0.0'.
     pattern : str, optional
         Glob-like pattern to select record IDs, by default '*'.
 
     Returns
     -------
-    List[str]
+    list[str]
         List containing record IDs as strings.
     """
     data_dir = Path(data_dir)
@@ -77,15 +77,15 @@ def download_physionet_records(
 
     Parameters
     ----------
-    data_dir : Path
+    data_dir : pathlib.Path
         Directory where all datasets are stored.
     db_slug : str
         Short identifier of a database, e.g. 'mitdb'.
-    requested_records : List[str]
+    requested_records : list[str]
         Records with those IDs are downloaded.
     extensions : Iterable[str]
         Files with those extensions are downloaded.
-    db_version : Optional[str], optional
+    db_version : str, optional
         Version of the database, by default '1.0.0'.
     """
     data_dir = Path(data_dir)
@@ -119,16 +119,16 @@ def _get_physionet_checksums(
 
     Parameters
     ----------
-    data_dir : Path
+    data_dir : pathlib.Path
         Directory where all datasets are stored.
     db_slug : str
         Short identifier of a database, e.g. 'mitdb'.
-    db_version : Optional[str], optional
+    db_version : str, optional
         Version of the database, by default '1.0.0'.
 
     Returns
     -------
-    Dict[str, str]
+    dict[str, str]
         Mapping of filenames to checksums.
     """
     checksum_url = f'{PHYSIONET_FILES_URL}/{db_slug}/{db_version}/{CHECKSUM_FILENAME}'

--- a/sleepecg/io/physionet_api.py
+++ b/sleepecg/io/physionet_api.py
@@ -2,6 +2,8 @@
 #
 # License: BSD (3-clause)
 
+"""Simple interface for downloading PhysioNet data."""
+
 import fnmatch
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional

--- a/sleepecg/io/physionet_api.py
+++ b/sleepecg/io/physionet_api.py
@@ -40,11 +40,11 @@ def list_physionet_records(
         Directory where all datasets are stored. Required to download the
         RECORDS-file.
     db_slug : str
-        Short identifier of a database, e.g. 'mitdb'.
+        Short identifier of a database, e.g. `'mitdb'`.
     db_version : str, optional
-        Version of the database, by default '1.0.0'.
+        Version of the database, by default `'1.0.0'`.
     pattern : str, optional
-        Glob-like pattern to select record IDs, by default '*'.
+        Glob-like pattern to select record IDs, by default `'*'`.
 
     Returns
     -------
@@ -82,13 +82,13 @@ def download_physionet_records(
     data_dir : pathlib.Path
         Directory where all datasets are stored.
     db_slug : str
-        Short identifier of a database, e.g. 'mitdb'.
+        Short identifier of a database, e.g. `'mitdb'`.
     requested_records : list[str]
         Records with those IDs are downloaded.
     extensions : Iterable[str]
         Files with those extensions are downloaded.
     db_version : str, optional
-        Version of the database, by default '1.0.0'.
+        Version of the database, by default `'1.0.0'`.
     """
     data_dir = Path(data_dir)
     checksums = _get_physionet_checksums(data_dir, db_slug, db_version)
@@ -124,9 +124,9 @@ def _get_physionet_checksums(
     data_dir : pathlib.Path
         Directory where all datasets are stored.
     db_slug : str
-        Short identifier of a database, e.g. 'mitdb'.
+        Short identifier of a database, e.g. `'mitdb'`.
     db_version : str, optional
-        Version of the database, by default '1.0.0'.
+        Version of the database, by default `'1.0.0'`.
 
     Returns
     -------

--- a/sleepecg/io/utils.py
+++ b/sleepecg/io/utils.py
@@ -66,11 +66,11 @@ def download_file(
     target_filepath : pathlib.Path
         Location where the downloaded file will be stored.
     checksum : str, optional
-        Checksum to verify the file against, by default None.
+        Checksum to verify the file against, by default `None`.
     checksum_type : str, optional
-        Type of the checksum, by default None.
+        Type of the checksum, by default `None`.
     verbose : bool, optional
-        If `True`, output information during download. By default False.
+        If `True`, output information during download. By default `False`.
     """
     if target_filepath.is_file():
         if checksum is not None and checksum_type is not None:

--- a/sleepecg/io/utils.py
+++ b/sleepecg/io/utils.py
@@ -2,6 +2,8 @@
 #
 # License: BSD (3-clause)
 
+"""I/O- and download-related utilities."""
+
 import hashlib
 from pathlib import Path
 from typing import Optional

--- a/sleepecg/io/utils.py
+++ b/sleepecg/io/utils.py
@@ -24,7 +24,7 @@ def _calculate_checksum(filepath: Path, checksum_type: str) -> str:
 
     Parameters
     ----------
-    filepath : Path
+    filepath : pathlib.Path
         Location of the file.
     checksum_type : {'md5', 'sha256'}
         Type of the checksum to calculate.
@@ -61,11 +61,11 @@ def download_file(
     ----------
     url : str
         URL to download from.
-    target_filepath : Path
+    target_filepath : pathlib.Path
         Location where the downloaded file will be stored.
-    checksum : Optional[str], optional
+    checksum : str, optional
         Checksum to verify the file against, by default None.
-    checksum_type : Optional[str], optional
+    checksum_type : str, optional
         Type of the checksum, by default None.
     verbose : bool, optional
         If `True`, output information during download. By default False.

--- a/sleepecg/tests/test_heartbeat_detection.py
+++ b/sleepecg/tests/test_heartbeat_detection.py
@@ -2,6 +2,8 @@
 #
 # License: BSD (3-clause)
 
+"""Tests for heartbeat detection and detector evaluation."""
+
 import sys
 
 import numpy as np


### PR DESCRIPTION
Sphinx is set up to build a recursive autosummary for the API reference, i.e. each new public function will be added there automatically.

A test-build is avaiable [here](https://test-sleepecg.readthedocs.io/en/latest/).

TODO:
- [x] Follow the instructions [here](https://docs.readthedocs.io/en/stable/intro/import-guide.html#importing-your-documentation) to link this repo to readthedocs. A webhook triggering builds will be created automatically. No workflow using GitHub Actions is required.
- [ ] After the next release, check whether different versions are shown and linked correctly.