### PR TITLE
Standardize return value docs

### DIFF
--- a/sleepecg/heartbeats.py
+++ b/sleepecg/heartbeats.py
@@ -86,7 +86,7 @@ def detect_heartbeats(ecg: np.ndarray, fs: float, backend: str = 'c') -> np.ndar
 
     Returns
     -------
-    heartbeat_indices: np.ndarray
+    np.ndarray
         Indices of detected heartbeats.
     """
     if backend not in _all_backends:
@@ -284,7 +284,7 @@ def _squared_moving_integration_py(x: np.ndarray, window_length: int) -> np.ndar
 
     Returns
     -------
-    output : np.ndarray
+    np.ndarray
         The squared and integrated array.
     """
     signal_len = len(x)
@@ -346,7 +346,7 @@ def _thresholding_py(
 
     Returns
     -------
-    beat_mask : np.ndarray
+    np.ndarray
         Array containing `1` for every sample in `filtered_ecg` identified
         as a heartbeat (i.e. R-peak).
     """

--- a/sleepecg/io/ecg_readers.py
+++ b/sleepecg/io/ecg_readers.py
@@ -72,7 +72,7 @@ def read_mitbih(
 
     Yields
     ------
-    Iterator[ECGRecord]
+    ECGRecord
         Each element in the generator is of type `ECGRecord` and contains
         the ECG signal (`.ecg`), sampling frequency (`.fs`), annotated beat
         indices (`.annotations`), `.lead`, and `.id`.
@@ -131,7 +131,7 @@ def read_gudb(data_dir: Union[str, Path], offline: bool = False) -> Iterator[ECG
 
     Yields
     ------
-    Iterator[ECGRecord]
+    ECGRecord
         Each element in the generator is of type `ECGRecord` and contains
         the ECG signal (`.ecg`), sampling frequency (`.fs`), annotated beat
         indices (`.annotations`), `.lead`, and `.id`.

--- a/sleepecg/io/nsrr.py
+++ b/sleepecg/io/nsrr.py
@@ -66,7 +66,7 @@ def get_nsrr_url(db_slug: str) -> str:
 
     Returns
     -------
-    download_url : str
+    str
         The download URL.
     """
     if _nsrr_token is None:


### PR DESCRIPTION
I'd suggest we follow the [pandas docstring guide](https://pandas.pydata.org/pandas-docs/stable/development/contributing_docstring.html#section-4-returns-or-yields) for documenting return values, since it's more specific than [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html#returns) in that matter;
- for single return values, only the type is stated (no name)
- for multiple return values, both a name and a type are stated
- generators are treated similarly, so a type annotation `Iterator[int]` becomes just `int` in the docstring