### PR TITLE
Add `io.read_mesa`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [UNRELEASED]
 ### Added
 - Configuration via a YAML file ([#39](https://github.com/cbrnr/sleepecg/pull/39) by [Florian Hofer](https://github.com/hofaflo))
+- Function for reading data from the [MESA](https://sleepdata.org/datasets/mesa) datasets ([#28](https://github.com/cbrnr/sleepecg/pull/28) by [Florian Hofer](https://github.com/hofaflo))
 
 ## [0.3.0] - 2021-08-25
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [UNRELEASED]
 ### Added
 - Configuration via a YAML file ([#39](https://github.com/cbrnr/sleepecg/pull/39) by [Florian Hofer](https://github.com/hofaflo))
-- Function for reading data from the [MESA](https://sleepdata.org/datasets/mesa) datasets ([#28](https://github.com/cbrnr/sleepecg/pull/28) by [Florian Hofer](https://github.com/hofaflo))
+- Add function for reading data from the [MESA](https://sleepdata.org/datasets/mesa) datasets ([#28](https://github.com/cbrnr/sleepecg/pull/28) by [Florian Hofer](https://github.com/hofaflo))
 
 ## [0.3.0] - 2021-08-25
 ### Added

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,10 +34,11 @@ install_requires =
 
 [options.extras_require]
 full =
+    mne>=0.23.0
     numba>=0.53.0
     pandas>=1.2.0
-    wfdb>=3.3.0
     pyEDFlib>=0.1.22
+    wfdb>=3.3.0
 
 dev =
     m2r2>=0.3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ full =
     numba>=0.53.0
     pandas>=1.2.0
     wfdb>=3.3.0
-    pyEFlib>=0.1.22
+    pyEDFlib>=0.1.22
 
 dev =
     m2r2>=0.3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ full =
     numba>=0.53.0
     pandas>=1.2.0
     wfdb>=3.3.0
+    pyEFlib>=0.1.22
 
 dev =
     m2r2>=0.3.0

--- a/sleepecg/io/__init__.py
+++ b/sleepecg/io/__init__.py
@@ -2,9 +2,10 @@
 
 from .ecg_readers import read_gudb, read_ltdb, read_mitdb
 from .nsrr import download_nsrr, set_nsrr_token
-from .sleep_readers import read_mesa
+from .sleep_readers import SleepRecord, read_mesa
 
 __all__ = [
+    'SleepRecord',
     'read_gudb',
     'read_ltdb',
     'read_mitdb',

--- a/sleepecg/io/__init__.py
+++ b/sleepecg/io/__init__.py
@@ -2,11 +2,13 @@
 
 from .ecg_readers import read_gudb, read_ltdb, read_mitdb
 from .nsrr import download_nsrr, set_nsrr_token
+from .sleep_readers import read_mesa
 
 __all__ = [
     'read_gudb',
     'read_ltdb',
     'read_mitdb',
+    'read_mesa',
     'set_nsrr_token',
     'download_nsrr',
 ]

--- a/sleepecg/io/__init__.py
+++ b/sleepecg/io/__init__.py
@@ -2,10 +2,9 @@
 
 from .ecg_readers import read_gudb, read_ltdb, read_mitdb
 from .nsrr import download_nsrr, set_nsrr_token
-from .sleep_readers import SleepRecord, read_mesa
+from .sleep_readers import read_mesa
 
 __all__ = [
-    'SleepRecord',
     'read_gudb',
     'read_ltdb',
     'read_mitdb',

--- a/sleepecg/io/sleep_readers.py
+++ b/sleepecg/io/sleep_readers.py
@@ -19,8 +19,6 @@ from .nsrr import get_nsrr_url, list_nsrr
 from .utils import download_file
 
 __all__ = [
-    'SleepRecord',
-    'SleepStage',
     'read_mesa',
 ]
 

--- a/sleepecg/io/sleep_readers.py
+++ b/sleepecg/io/sleep_readers.py
@@ -185,7 +185,7 @@ def read_mesa(
     if not offline:
         download_url = get_nsrr_url(DB_SLUG)
 
-    db_dir = Path(data_dir) / DB_SLUG
+    db_dir = Path(data_dir).expanduser() / DB_SLUG
     annotations_dir = db_dir / ANNOTATION_DIRNAME
     edf_dir = db_dir / EDF_DIRNAME
     heartbeats_dir = db_dir / HEARTBEATS_DIRNAME

--- a/sleepecg/io/sleep_readers.py
+++ b/sleepecg/io/sleep_readers.py
@@ -146,7 +146,7 @@ def read_mesa(
     polysomnography data and an `.xml` file containing annotated events.
     Since the entire MESA dataset requires about 385 GB of disk space,
     `.edf` files can be deleted after heartbeat times have been extracted.
-    Heartbeat times are cached in a `.npy` file in
+    Heartbeat times are cached in an `.npy` file in
     `<data_dir>/mesa/preprocessed/heartbeats`.
 
     Parameters

--- a/sleepecg/io/sleep_readers.py
+++ b/sleepecg/io/sleep_readers.py
@@ -49,8 +49,8 @@ class SleepRecord:
     sleep_stages : np.ndarray, optional
         Sleep stages according to AASM guidelines, stored as integers as
         defined by `SleepStage`, by default `None`
-    fs_sleep_stages : float, optional
-        Sampling frequency of attribute `sleep_stages`, by default `None`
+    sleep_stage_duration : int, optional
+        Duration of each sleep stage in seconds, by default `None`
     id : str, optional
         The record's ID, by default `None`.
     recording_start_time : datetime.time, optional
@@ -61,7 +61,7 @@ class SleepRecord:
     """
 
     sleep_stages: Optional[np.ndarray] = None
-    fs_sleep_stages: Optional[float] = None
+    sleep_stage_duration: Optional[int] = None
     id: Optional[str] = None
     recording_start_time: Optional[datetime.time] = None
     heartbeat_times: Optional[np.ndarray] = None
@@ -69,7 +69,7 @@ class SleepRecord:
 
 class _ParseNsrrXmlResult(NamedTuple):
     sleep_stages: np.ndarray
-    fs_sleep_stages: float
+    sleep_stage_duration: int
     recording_start_time: datetime.time
 
 
@@ -129,7 +129,7 @@ def _parse_nsrr_xml(xml_filepath: Path) -> _ParseNsrrXmlResult:
 
     return _ParseNsrrXmlResult(
         np.array(annot_stages, dtype=np.int8),
-        1 / epoch_length,
+        epoch_length,
         start_time,
     )
 
@@ -257,7 +257,7 @@ def read_mesa(
 
         yield SleepRecord(
             sleep_stages=parsed_xml.sleep_stages,
-            fs_sleep_stages=parsed_xml.fs_sleep_stages,
+            sleep_stage_duration=parsed_xml.sleep_stage_duration,
             id=record_id,
             recording_start_time=parsed_xml.recording_start_time,
             heartbeat_times=heartbeat_times,

--- a/sleepecg/io/sleep_readers.py
+++ b/sleepecg/io/sleep_readers.py
@@ -13,6 +13,7 @@ from xml.etree import ElementTree
 
 import numpy as np
 
+from ..config import get_config
 from ..heartbeats import detect_heartbeats
 from .nsrr import get_nsrr_url, list_nsrr
 from .utils import download_file
@@ -135,7 +136,7 @@ def _parse_nsrr_xml(xml_filepath: Path) -> _ParseNsrrXmlResult:
 
 
 def read_mesa(
-    data_dir: Union[str, Path],
+    data_dir: Optional[Union[str, Path]] = None,
     records_pattern: str = '*',
     use_preprocessed_heartbeats: bool = True,
     offline: bool = False,
@@ -154,7 +155,8 @@ def read_mesa(
     Parameters
     ----------
     data_dir : str | pathlib.Path
-        Directory where all datasets are stored.
+        Directory where all datasets are stored. If `None` (default), the
+        value will be taken from the configuration.
     records_pattern : str, optional
          Glob-like pattern to select record IDs, by default `'*'`.
     use_preprocessed_heartbeats : bool, optional
@@ -181,6 +183,9 @@ def read_mesa(
     ANNOTATION_DIRNAME = 'polysomnography/annotations-events-nsrr'
     EDF_DIRNAME = 'polysomnography/edfs'
     HEARTBEATS_DIRNAME = 'preprocessed/heartbeats'
+
+    if data_dir is None:
+        data_dir = get_config('data_dir')
 
     if not offline:
         download_url = get_nsrr_url(DB_SLUG)

--- a/sleepecg/io/sleep_readers.py
+++ b/sleepecg/io/sleep_readers.py
@@ -172,9 +172,7 @@ def read_mesa(
     Yields
     ------
     SleepRecord
-        Each element in the generator is a `SleepRecord`, containing
-        heartbeat times, sleep stages, sleep stage sampling frequency,
-        record ID and record start time.
+        Each element in the generator is a :class:`SleepRecord`.
     """
     from mne.io import read_raw_edf
 

--- a/sleepecg/io/sleep_readers.py
+++ b/sleepecg/io/sleep_readers.py
@@ -46,24 +46,25 @@ class SleepRecord:
 
     Attributes
     ----------
-    heartbeat_times : np.ndarray
-        Times of heartbeats after ECG signal onset in seconds.
-    sleep_stages : np.ndarray
+    sleep_stages : np.ndarray, optional
         Sleep stages according to AASM guidelines, stored as integers as
-        defined by `SleepStage`.
-    fs_sleep_stages : float
-        Sampling frequency of attribute `sleep_stages`.
-    id : Optional[str] = ''
-        The record's ID, by default `''`.
+        defined by `SleepStage`, by default `None`
+    fs_sleep_stages : float, optional
+        Sampling frequency of attribute `sleep_stages`, by default `None`
+    id : str, optional
+        The record's ID, by default `None`.
     recording_start_time : datetime.time, optional
         Time at which the recording was started, by default `None`.
+    heartbeat_times : np.ndarray, optional
+        Times of heartbeats after ECG signal onset in seconds, by default
+        `None`.
     """
 
-    heartbeat_times: np.ndarray
-    sleep_stages: np.ndarray
-    fs_sleep_stages: float
-    id: Optional[str] = ''
+    sleep_stages: Optional[np.ndarray] = None
+    fs_sleep_stages: Optional[float] = None
+    id: Optional[str] = None
     recording_start_time: Optional[datetime.time] = None
+    heartbeat_times: Optional[np.ndarray] = None
 
 
 class _ParseNsrrXmlResult(NamedTuple):
@@ -255,9 +256,9 @@ def read_mesa(
         parsed_xml = _parse_nsrr_xml(xml_filepath)
 
         yield SleepRecord(
-            heartbeat_times,
-            parsed_xml.sleep_stages,
-            parsed_xml.fs_sleep_stages,
+            sleep_stages=parsed_xml.sleep_stages,
+            fs_sleep_stages=parsed_xml.fs_sleep_stages,
             id=record_id,
             recording_start_time=parsed_xml.recording_start_time,
+            heartbeat_times=heartbeat_times,
         )

--- a/sleepecg/io/sleep_readers.py
+++ b/sleepecg/io/sleep_readers.py
@@ -139,7 +139,7 @@ def read_mesa(
     records_pattern: str = '*',
     use_cached_heartbeats: bool = True,
     offline: bool = False,
-    persist_edfs: bool = False,
+    keep_edfs: bool = False,
 ) -> Iterator[SleepRecord]:
     """
     Lazily read records from MESA (https://sleepdata.org/datasets/mesa).
@@ -165,7 +165,7 @@ def read_mesa(
     offline : bool, optional
         If `True`, search for local files only instead of using the NSRR
         API, by default `False`.
-    persist_edfs : bool, optional
+    keep_edfs : bool, optional
         If `False`, remove `.edf` after heartbeat detection, by default
         `False`.
 
@@ -244,7 +244,7 @@ def read_mesa(
             heartbeat_times = heartbeat_indices / fs
             np.save(heartbeats_file, heartbeat_times)
 
-            if not edf_was_available and not persist_edfs:
+            if not edf_was_available and not keep_edfs:
                 edf_filepath.unlink()
 
         xml_filename = ANNOTATION_DIRNAME + f'/{record_id}-nsrr.xml'

--- a/sleepecg/io/sleep_readers.py
+++ b/sleepecg/io/sleep_readers.py
@@ -56,8 +56,8 @@ class SleepRecord:
     recording_start_time : datetime.time, optional
         Time at which the recording was started, by default `None`.
     heartbeat_times : np.ndarray, optional
-        Times of heartbeats after ECG signal onset in seconds, by default
-        `None`.
+        Times of heartbeats relative to recording start in seconds, by
+        default `None`.
     """
 
     sleep_stages: Optional[np.ndarray] = None

--- a/sleepecg/io/sleep_readers.py
+++ b/sleepecg/io/sleep_readers.py
@@ -134,9 +134,9 @@ def _parse_nsrr_xml(xml_filepath: Path) -> _ParseNsrrXmlResult:
 def read_mesa(
     data_dir: Union[str, Path],
     records_pattern: str = '*',
-    use_preprocessed_heartbeats: Optional[bool] = True,
-    offline: Optional[bool] = False,
-    persist_edfs: Optional[bool] = False,
+    use_preprocessed_heartbeats: bool = True,
+    offline: bool = False,
+    persist_edfs: bool = False,
 ) -> Iterator[SleepRecord]:
     """
     Lazily reads records from MESA (https://sleepdata.org/datasets/mesa).

--- a/sleepecg/io/sleep_readers.py
+++ b/sleepecg/io/sleep_readers.py
@@ -18,6 +18,8 @@ from .nsrr import get_nsrr_url, list_nsrr
 from .utils import download_file
 
 __all__ = [
+    'SleepRecord',
+    'SleepStage',
     'read_mesa',
 ]
 

--- a/sleepecg/io/sleep_readers.py
+++ b/sleepecg/io/sleep_readers.py
@@ -218,7 +218,7 @@ def read_mesa(
     else:
         xml_files = sorted(annotations_dir.glob(f'mesa-sleep-{records_pattern}-nsrr.xml'))
         requested_records = [file.stem[:-5] for file in xml_files]
-        if not use_preprocessed_heartbeats:
+        if not use_cached_heartbeats:
             edf_files = sorted(edf_dir.glob(f'mesa-sleep-{records_pattern}.edf'))
 
     for record_id in requested_records:

--- a/sleepecg/io/sleep_readers.py
+++ b/sleepecg/io/sleep_readers.py
@@ -144,7 +144,7 @@ def read_mesa(
     """
     Lazily read records from MESA (https://sleepdata.org/datasets/mesa).
 
-    Each MESA record consists of a `.edf` file containing raw
+    Each MESA record consists of an `.edf` file containing raw
     polysomnography data and an `.xml` file containing annotated events.
     Since the entire MESA dataset requires about 385 GB of disk space,
     `.edf` files can be deleted after heartbeat times have been extracted.

--- a/sleepecg/io/sleep_readers.py
+++ b/sleepecg/io/sleep_readers.py
@@ -1,0 +1,261 @@
+# Authors: Florian Hofer
+#
+# License: BSD (3-clause)
+
+"""Read datasets containing ECG data and sleep stage annotations."""
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import IntEnum
+from pathlib import Path
+from typing import Iterator, NamedTuple, Optional, Union
+from xml.etree import ElementTree
+
+import numpy as np
+
+from ..heartbeats import detect_heartbeats
+from .nsrr import get_nsrr_url, list_nsrr
+from .utils import download_file
+
+__all__ = [
+    'read_mesa',
+]
+
+
+class SleepStage(IntEnum):
+    """
+    Mapping of AASM sleep stages to integers.
+
+    To facilitate hypnogram plotting, values increase with wakefulness.
+    """
+
+    WAKE = 5
+    REM = 4
+    N1 = 3
+    N2 = 2
+    N3 = 1
+    UNDEFINED = -1
+
+
+@dataclass
+class SleepRecord:
+    """
+    Dataclass to store a single sleep record.
+
+    Attributes
+    ----------
+    heartbeat_times : np.ndarray
+        Times of heartbeats after ECG signal onset in seconds.
+    sleep_stages : np.ndarray
+        Sleep stages according to AASM guidelines, stored as integers as
+        defined by `SleepStage`.
+    fs_sleep_stages : float
+        Sampling frequency of attribute `sleep_stages`.
+    id : Optional[str] = ''
+        The record's ID, by default `''`
+    recording_start_time : Optional[np.datetime64] = None
+        Time at which the recording was started.
+    """
+
+    heartbeat_times: np.ndarray
+    sleep_stages: np.ndarray
+    fs_sleep_stages: float
+    id: Optional[str] = ''
+    recording_start_time: Optional[np.datetime64] = None
+
+
+class _ParseNsrrXmlResult(NamedTuple):
+    sleep_stages: np.ndarray
+    fs_sleep_stages: float
+    recording_start_time: np.datetime64
+
+
+def _parse_nsrr_xml(xml_filepath: Path) -> _ParseNsrrXmlResult:
+    """
+    Parse NSRR xml sleep stage annotation file.
+
+    Parameters
+    ----------
+    xml_filepath : pathlib.Path
+        Path of the annotation file to read.
+
+    Returns
+    -------
+    sleep_stages : np.ndarray
+        Sleep stages according to AASM guidelines, stored as integers as
+        defined by `SleepStage`.
+    fs_sleep_stages : float
+        Sampling frequency of `sleep_stages`.
+    recording_start_time : np.datetime64
+        Time at which the recording was started.
+
+    """
+    STAGE_MAPPING = {
+        'Wake|0': SleepStage.WAKE,
+        'Stage 1 sleep|1': SleepStage.N1,
+        'Stage 2 sleep|2': SleepStage.N2,
+        'Stage 3 sleep|3': SleepStage.N3,
+        'Stage 4 sleep|4': SleepStage.N3,
+        'REM sleep|5': SleepStage.REM,
+        'Unscored|9': SleepStage.UNDEFINED,
+    }
+
+    tree = ElementTree.parse(xml_filepath)
+    root = tree.getroot()
+
+    epoch_length = root.findtext('EpochLength')
+    if epoch_length is None:
+        raise RuntimeError(f'EpochLength not found in {xml_filepath}.')
+    epoch_length = int(epoch_length)
+
+    start_time = None
+    annot_stages = []
+
+    for event in root.find('ScoredEvents'):
+        if event.find('EventConcept').text == 'Recording Start Time':
+            start_time = event.find('ClockTime').text.split()[1]
+            start_time = datetime.strptime(start_time, '%H.%M.%S')
+
+        if event.find('EventType').text == 'Stages|Stages':
+            epoch_duration = int(float(event.findtext('Duration')))
+            stage = STAGE_MAPPING[event.findtext('EventConcept')]
+            annot_stages.extend([stage] * int(epoch_duration / epoch_length))
+
+    if start_time is None:
+        raise RuntimeError(f'"Recording Start Time" not found in {xml_filepath}.')
+
+    return _ParseNsrrXmlResult(
+        np.array(annot_stages, dtype=np.int8),
+        1 / epoch_length,
+        np.datetime64(start_time),
+    )
+
+
+def read_mesa(
+    data_dir: Union[str, Path],
+    records_pattern: str = '*',
+    use_preprocessed_heartbeats: Optional[bool] = True,
+    offline: Optional[bool] = False,
+    persist_edfs: Optional[bool] = False,
+) -> Iterator[SleepRecord]:
+    """
+    Lazily reads records from MESA (https://sleepdata.org/datasets/mesa).
+
+    Each MESA record consists of a `.edf` files containing raw
+    polysomnography data and an `.xml` files containing annotated events.
+    Since the entire MESA dataset requires about 385 GB of disk space,
+    `.edf` files can be deleted after the heartbeat times have been
+    extracted. Heartbeat times are stored to a `.npy` file in
+    `<data_dir>/mesa/preprocessed/heartbeats`.
+
+    Parameters
+    ----------
+    data_dir : str | pathlib.Path
+        Directory where all datasets are stored.
+    records_pattern : str, optional
+         Glob-like pattern to select record IDs, by default `'*'`.
+    use_preprocessed_heartbeats : bool, optional
+        If `True`, get heartbeat times directly from the stored `.npy`
+        file, so `.edf` files are only downloaded for records which have
+        not yet been preprocessed. By default `True`.
+    offline : bool, optional
+        If `True`, search for local files only instead of using the NSRR
+        API, by default `False`.
+    persist_edfs : bool, optional
+        If `False`, remove `.edf` after heartbeat detection, by default
+        `False`.
+
+    Yields
+    ------
+    SleepRecord
+        Each element in the generator is a `SleepRecord`, containing
+        heartbeat times, sleep stages, sleep stage sampling frequency,
+        record ID and record start time.
+    """
+    from mne.io import read_raw_edf
+
+    DB_SLUG = 'mesa'
+    ANNOTATION_DIRNAME = 'polysomnography/annotations-events-nsrr'
+    EDF_DIRNAME = 'polysomnography/edfs'
+    HEARTBEATS_DIRNAME = 'preprocessed/heartbeats'
+
+    if not offline:
+        download_url = get_nsrr_url(DB_SLUG)
+
+    db_dir = Path(data_dir) / DB_SLUG
+    annotations_dir = db_dir / ANNOTATION_DIRNAME
+    edf_dir = db_dir / EDF_DIRNAME
+    heartbeats_dir = db_dir / HEARTBEATS_DIRNAME
+
+    for directory in (annotations_dir, edf_dir, heartbeats_dir):
+        directory.mkdir(parents=True, exist_ok=True)
+
+    if not offline:
+        checksums = {}
+        xml_files = list_nsrr(
+            DB_SLUG,
+            ANNOTATION_DIRNAME,
+            f'mesa-sleep-{records_pattern}-nsrr.xml',
+            shallow=True,
+        )
+        checksums.update(xml_files)
+        requested_records = [Path(file).stem[:-5] for file, _ in xml_files]
+
+        edf_files = list_nsrr(
+            DB_SLUG,
+            EDF_DIRNAME,
+            f'mesa-sleep-{records_pattern}.edf',
+            shallow=True,
+        )
+        checksums.update(edf_files)
+    else:
+        xml_files = sorted(annotations_dir.glob(f'mesa-sleep-{records_pattern}-nsrr.xml'))
+        requested_records = [file.stem[:-5] for file in xml_files]
+        if not use_preprocessed_heartbeats:
+            edf_files = sorted(edf_dir.glob(f'mesa-sleep-{records_pattern}.edf'))
+
+    for record_id in requested_records:
+        heartbeats_file = heartbeats_dir / f'{record_id}.npy'
+        if use_preprocessed_heartbeats and heartbeats_file.is_file():
+            heartbeat_times = np.load(heartbeats_file)
+        else:
+            edf_filename = EDF_DIRNAME + f'/{record_id}.edf'
+            edf_filepath = db_dir / edf_filename
+            edf_was_available = edf_filepath.is_file()
+            if not offline:
+                download_file(
+                    download_url + edf_filename,
+                    edf_filepath,
+                    checksums[edf_filename],
+                    'md5',
+                )
+
+            rec = read_raw_edf(edf_filepath, verbose=False)
+            ecg = rec.get_data('EKG').ravel()
+            fs = rec.info['sfreq']
+            heartbeat_indices = detect_heartbeats(ecg, fs)
+            heartbeat_times = heartbeat_indices / fs
+            np.save(heartbeats_file, heartbeat_times)
+
+            if not edf_was_available and not persist_edfs:
+                edf_filepath.unlink()
+
+        xml_filename = ANNOTATION_DIRNAME + f'/{record_id}-nsrr.xml'
+        xml_filepath = db_dir / xml_filename
+        if not offline:
+            download_file(
+                download_url + xml_filename,
+                xml_filepath,
+                checksums[xml_filename],
+                'md5',
+            )
+
+        parsed_xml = _parse_nsrr_xml(xml_filepath)
+
+        yield SleepRecord(
+            heartbeat_times,
+            parsed_xml.sleep_stages,
+            parsed_xml.fs_sleep_stages,
+            id=record_id,
+            recording_start_time=parsed_xml.recording_start_time,
+        )

--- a/sleepecg/io/sleep_readers.py
+++ b/sleepecg/io/sleep_readers.py
@@ -147,8 +147,8 @@ def read_mesa(
     Each MESA record consists of a `.edf` file containing raw
     polysomnography data and an `.xml` file containing annotated events.
     Since the entire MESA dataset requires about 385 GB of disk space,
-    `.edf` files can be deleted after heartbeat times have been
-    extracted. Heartbeat times are cached in a `.npy` file in
+    `.edf` files can be deleted after heartbeat times have been extracted.
+    Heartbeat times are cached in a `.npy` file in
     `<data_dir>/mesa/preprocessed/heartbeats`.
 
     Parameters

--- a/sleepecg/test/test_sleep_readers.py
+++ b/sleepecg/test/test_sleep_readers.py
@@ -79,11 +79,7 @@ def _dummy_mesa_xml(filename: str, hours: float, random_state):
         )
 
 
-def _create_dummy_mesa(
-    data_dir: str,
-    durations: List[float],
-    random_state,
-):
+def _create_dummy_mesa(data_dir: str, durations: List[float], random_state):
     DB_SLUG = 'mesa'
     ANNOTATION_DIRNAME = 'polysomnography/annotations-events-nsrr'
     EDF_DIRNAME = 'polysomnography/edfs'

--- a/sleepecg/test/test_sleep_readers.py
+++ b/sleepecg/test/test_sleep_readers.py
@@ -28,7 +28,7 @@ def _dummy_mesa_edf(filename: str, hours: float):
         highlevel.write_edf(filename, ecg, signal_headers)
 
 
-def _dummy_mesa_xml(filename: str, hours: float, random_state):
+def _dummy_mesa_xml(filename: str, hours: float, random_state: int):
     EPOCH_LENGTH = 30
     STAGES = [
         'Wake|0',
@@ -79,7 +79,7 @@ def _dummy_mesa_xml(filename: str, hours: float, random_state):
         )
 
 
-def _create_dummy_mesa(data_dir: str, durations: List[float], random_state):
+def _create_dummy_mesa(data_dir: str, durations: List[float], random_state: int = 42):
     DB_SLUG = 'mesa'
     ANNOTATION_DIRNAME = 'polysomnography/annotations-events-nsrr'
     EDF_DIRNAME = 'polysomnography/edfs'
@@ -103,7 +103,7 @@ def test_read_mesa():
     durations = [0.1, 0.2]  # hours
     valid_stages = {int(s) for s in SleepStage}
 
-    _create_dummy_mesa(data_dir=data_dir, durations=durations, random_state=42)
+    _create_dummy_mesa(data_dir=data_dir, durations=durations)
     records = list(read_mesa(data_dir=data_dir, offline=True))
 
     assert len(records) == 2

--- a/sleepecg/test/test_sleep_readers.py
+++ b/sleepecg/test/test_sleep_readers.py
@@ -21,7 +21,7 @@ def _dummy_mesa_edf(filename: str, hours: float):
     ecg_5_min = scipy.misc.electrocardiogram()
     seconds = int(hours * 60 * 60)
     ecg = np.tile(ecg_5_min, int(np.ceil(seconds / 300)))[:seconds * ECG_FS, np.newaxis].T
-    signal_headers = highlevel.make_signal_headers(['EKG'], sample_rate=ECG_FS)
+    signal_headers = highlevel.make_signal_headers(['EKG'], sample_frequency=ECG_FS)
     highlevel.write_edf(filename, ecg, signal_headers)
 
 

--- a/sleepecg/test/test_sleep_readers.py
+++ b/sleepecg/test/test_sleep_readers.py
@@ -4,6 +4,7 @@
 
 """Tests for sleep data reader functions."""
 
+import warnings
 from pathlib import Path
 from typing import List
 
@@ -20,9 +21,11 @@ def _dummy_mesa_edf(filename: str, hours: float):
     ECG_FS = 360
     ecg_5_min = scipy.misc.electrocardiogram()
     seconds = int(hours * 60 * 60)
-    ecg = np.tile(ecg_5_min, int(np.ceil(seconds / 300)))[:seconds * ECG_FS, np.newaxis].T
+    ecg = np.tile(ecg_5_min, int(np.ceil(seconds / 300)))[np.newaxis, :seconds * ECG_FS]
     signal_headers = highlevel.make_signal_headers(['EKG'], sample_frequency=ECG_FS)
-    highlevel.write_edf(filename, ecg, signal_headers)
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore')
+        highlevel.write_edf(filename, ecg, signal_headers)
 
 
 def _dummy_mesa_xml(filename: str, hours: float):

--- a/sleepecg/test/test_sleep_readers.py
+++ b/sleepecg/test/test_sleep_readers.py
@@ -1,0 +1,111 @@
+# Authors: Florian Hofer
+#
+# License: BSD (3-clause)
+
+"""Tests for sleep data reader functions."""
+
+from pathlib import Path
+from typing import List
+
+import numpy as np
+import scipy.misc
+from pyedflib import highlevel
+
+from sleepecg import get_config
+from sleepecg.io import read_mesa
+from sleepecg.io.sleep_readers import SleepStage
+
+
+def _dummy_mesa_edf(filename: str, hours: float):
+    ECG_FS = 360
+    ecg_5_min = scipy.misc.electrocardiogram()
+    seconds = int(hours * 60 * 60)
+    ecg = np.tile(ecg_5_min, int(np.ceil(seconds / 300)))[:seconds * ECG_FS, np.newaxis].T
+    signal_headers = highlevel.make_signal_headers(['EKG'], sample_rate=ECG_FS)
+    highlevel.write_edf(filename, ecg, signal_headers)
+
+
+def _dummy_mesa_xml(filename: str, hours: float):
+    EPOCH_LENGTH = 30
+    STAGES = [
+        'Wake|0',
+        'Stage 1 sleep|1',
+        'Stage 2 sleep|2',
+        'Stage 3 sleep|3',
+        'Stage 4 sleep|4',
+        'REM sleep|5',
+        'Unscored|9',
+    ]
+
+    with open(filename, 'w') as xml_file:
+        xml_file.write(
+            '<?xml version="1.0" encoding="UTF-8" standalone="no"?>\n'
+            '<PSGAnnotation>\n'
+
+            f'<EpochLength>{EPOCH_LENGTH}</EpochLength>\n'
+
+            '<ScoredEvents>\n'
+            '<ScoredEvent>\n'
+            '<EventType/>\n'
+            '<EventConcept>Recording Start Time</EventConcept>\n'
+            '<ClockTime>01.01.85 20.29.59</ClockTime>\n'
+            '</ScoredEvent>\n',
+        )
+        record_duration = hours * 60 * 60
+        start = 0
+        while True:
+            if start > record_duration:
+                break
+            epoch_duration = np.random.choice(np.arange(4, 21)) * EPOCH_LENGTH
+            stage = np.random.choice(STAGES)
+            xml_file.write(
+                '<ScoredEvent>\n'
+                '<EventType>Stages|Stages</EventType>\n'
+                f'<EventConcept>{stage}</EventConcept>\n'
+                f'<Start>{start:.1f}</Start>\n'
+                f'<Duration>{epoch_duration:.1f}</Duration>\n'
+                '</ScoredEvent>\n',
+            )
+            start += epoch_duration
+
+        xml_file.write(
+            '</ScoredEvents>\n'
+            '</PSGAnnotation>\n',
+        )
+
+
+def _create_dummy_mesa(
+    data_dir: str,
+    durations: List[float],
+):
+    DB_SLUG = 'mesa'
+    ANNOTATION_DIRNAME = 'polysomnography/annotations-events-nsrr'
+    EDF_DIRNAME = 'polysomnography/edfs'
+
+    db_dir = Path(data_dir).expanduser() / DB_SLUG
+    annotations_dir = db_dir / ANNOTATION_DIRNAME
+    edf_dir = db_dir / EDF_DIRNAME
+
+    for directory in (annotations_dir, edf_dir):
+        directory.mkdir(parents=True, exist_ok=True)
+
+    for i, hours in enumerate(durations):
+        record_id = f'mesa-sleep-dummy-{i:04}'
+        _dummy_mesa_edf(f'{edf_dir}/{record_id}.edf', hours)
+        _dummy_mesa_xml(f'{annotations_dir}/{record_id}-nsrr.xml', hours)
+
+
+def test_read_mesa():
+    """Basic sanity checks for records read via read_mesa."""
+    data_dir = get_config('testdata_dir')
+    durations = [0.1, 0.2]  # hours
+    valid_stages = {int(s) for s in SleepStage}
+
+    _create_dummy_mesa(data_dir=data_dir, durations=durations)
+    records = list(read_mesa(data_dir=data_dir, offline=True))
+
+    assert len(records) == 2
+
+    for rec in records:
+        assert rec.sleep_stage_duration == 30
+        assert set(rec.sleep_stages) - valid_stages == set()


### PR DESCRIPTION
Add a reader function for the [MESA](https://sleepdata.org/datasets/mesa) dataset. 

This PR also establishes the data structures which should be used by all other readers:
- `SleepRecord`: A `dataclass` for storing a single record consisting of heartbeat times and annotates stages.
- `SleepStage`: An `IntEnum` mapping AASM sleep stage identifiers to integers (will be required for classification and plotting).