### PR TITLE
Add configuration interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [UNRELEASED]
 ### Added
-- Configuration via a yaml-file ([#39](https://github.com/cbrnr/sleepecg/pull/39) by [Florian Hofer](https://github.com/hofaflo))
+- Configuration via a YAML file ([#39](https://github.com/cbrnr/sleepecg/pull/39) by [Florian Hofer](https://github.com/hofaflo))
 
 ## [0.3.0] - 2021-08-25
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [UNRELEASED]
+### Added
+- Configuration via a yaml-file ([#39](https://github.com/cbrnr/sleepecg/pull/39) by [Florian Hofer](https://github.com/hofaflo))
 
 ## [0.3.0] - 2021-08-25
 ### Added

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 graft examples
 prune **/__pycache__
+include sleepecg/config.yml

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -9,7 +9,6 @@ import os
 import sys
 
 import sleepecg
-import sleepecg.globals
 
 # -- Project information --------------------------------------------------
 project = 'SleepECG'
@@ -18,7 +17,7 @@ copyright = '2021, SleepECG Developers'
 version = sleepecg.__version__
 
 rst_epilog = f"""
-.. |DATA_DIR| replace:: `'{sleepecg.globals.DATA_DIR}'`
+.. |DATA_DIR| replace:: `'{sleepecg.get_config('data_dir')}'`
 """
 
 # -- General configuration ------------------------------------------------

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -16,10 +16,6 @@ author = 'Florian Hofer'
 copyright = '2021, SleepECG Developers'
 version = sleepecg.__version__
 
-rst_epilog = f"""
-.. |DATA_DIR| replace:: `'{sleepecg.get_config('data_dir')}'`
-"""
-
 # -- General configuration ------------------------------------------------
 extensions = [
     'sphinx.ext.autodoc',

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ install_requires =
     requests>=2.25.0
     scipy>=1.6.0
     tqdm>=4.59.0
+    PyYAML>=5.4.0
 
 
 [options.extras_require]

--- a/sleepecg/__init__.py
+++ b/sleepecg/__init__.py
@@ -1,6 +1,7 @@
 """A package for sleep stage classification using ECG data."""
 
 from . import io
+from .config import get_config, set_config
 from .heartbeats import compare_heartbeats, detect_heartbeats, rri_similarity
 
 __all__ = [
@@ -8,6 +9,8 @@ __all__ = [
     'detect_heartbeats',
     'compare_heartbeats',
     'rri_similarity',
+    'get_config',
+    'set_config',
 ]
 
 __version__ = '0.4.0-dev'

--- a/sleepecg/config.py
+++ b/sleepecg/config.py
@@ -61,11 +61,10 @@ def get_config(key: Optional[str] = None) -> Any:
 
     if key is None:
         return config
-    try:
-        return config[key]
-    except KeyError:
+    if key not in config:
         options = ', '.join(config)
-        raise ValueError(f'Trying to get invalid config key: {key!r}, possible options: {options}') from None  # noqa: E501
+        raise ValueError(f'Trying to get invalid config key: {key!r}, possible options: {options}')  # noqa: E501
+    return config[key]
 
 
 def set_config(**kwargs):

--- a/sleepecg/config.py
+++ b/sleepecg/config.py
@@ -25,6 +25,8 @@ def _read_yaml(path: Path) -> Dict[str, Any]:
         # empty .yml-files are loaded as `None`
         if cfg is None:
             return {}
+        if not isinstance(cfg, dict):
+            raise ValueError(f'Invalid YAML config file at {_USER_CONFIG_PATH}')
         return cfg
 
 
@@ -49,7 +51,11 @@ def get_config(key: Optional[str] = None) -> Any:
     """
     config = _read_yaml(_DEFAULT_CONFIG_PATH)
     with contextlib.suppress(FileNotFoundError):
-        config.update(_read_yaml(_USER_CONFIG_PATH))
+        user_config = _read_yaml(_USER_CONFIG_PATH)
+        for key in user_config:
+            if key not in config:
+                raise ValueError(f'Invalid key found in user config at {_USER_CONFIG_PATH}: {key}')  # noqa: E501
+        config.update(user_config)
 
     if key is None:
         return config

--- a/sleepecg/config.py
+++ b/sleepecg/config.py
@@ -94,5 +94,6 @@ def set_config(**kwargs):
         else:
             user_config[key] = value
 
+    _USER_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
     with open(_USER_CONFIG_PATH, 'w') as user_config_file:
         yaml.dump(user_config, user_config_file)

--- a/sleepecg/config.py
+++ b/sleepecg/config.py
@@ -22,14 +22,15 @@ def _read_yaml(path: Path) -> Dict[str, Any]:
     try:
         with open(path) as file:
             cfg = yaml.safe_load(file)
-            # empty .yml-files are loaded as `None`
-            if cfg is None:
-                return {}
-            if not isinstance(cfg, dict):
-                raise ValueError(f'Invalid YAML config file at {_USER_CONFIG_PATH}')
-            return cfg
     except FileNotFoundError:
         return {}
+
+    # empty .yml-files are loaded as `None`
+    if cfg is None:
+        return {}
+    if not isinstance(cfg, dict):
+        raise ValueError(f'Invalid YAML config file at {path}')
+    return cfg
 
 
 def get_config(key: Optional[str] = None) -> Any:

--- a/sleepecg/config.py
+++ b/sleepecg/config.py
@@ -1,0 +1,98 @@
+# Authors: Florian Hofer
+#
+# License: BSD (3-clause)
+
+"""Functions for getting and setting configuration values."""
+
+import contextlib
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import yaml
+
+__all__ = [
+    'get_config',
+    'set_config',
+]
+
+_DEFAULT_CONFIG_PATH = Path(__file__).parent / 'config.yml'
+_USER_CONFIG_PATH = Path('~/.sleepecg/config.yml').expanduser()
+
+
+def _read_yaml(path: Path) -> Dict[str, Any]:
+    with open(path) as file:
+        cfg = yaml.safe_load(file)
+        # empty .yml-files are loaded as `None`
+        if cfg is None:
+            return {}
+        return cfg
+
+
+def get_config(key: Optional[str] = None) -> Any:
+    """
+    Read SleepECG preferences from the configuration file.
+
+    For parameters not set in the user configuration file
+    (`~/.sleepecg/config.yml`), this falls back to the default values
+    defined in `site-packages/sleepecg/config.yml`.
+
+    Parameters
+    ----------
+    key : str, optional
+        The configuration key to look for. If `None`, all configuration
+        settings are returned in a dictionary, by default `None`.
+
+    Returns
+    -------
+    typing.Any
+        The configuration value.
+    """
+    config = _read_yaml(_DEFAULT_CONFIG_PATH)
+    with contextlib.suppress(FileNotFoundError):
+        config.update(_read_yaml(_USER_CONFIG_PATH))
+
+    if key is None:
+        return config
+    try:
+        return config[key]
+    except KeyError:
+        options = ', '.join(config)
+        raise ValueError(f'Trying to get invalid config key: {key!r}, possible options: {options}') from None  # noqa: E501
+
+
+def set_config(**kwargs):
+    """
+    Set SleepECG preferences and store them to the user configuration file.
+
+    If a value is `None`, the corresponding key is deleted from the user
+    configuration.
+
+    Parameters
+    ----------
+    **kwargs: dict, optional
+        The configuration keys and values to set.
+
+    Examples
+    --------
+    >>> set_config(data_dir='~/.sleepecg/datasets')
+    """
+    default_config = _read_yaml(_DEFAULT_CONFIG_PATH)
+    try:
+        user_config = _read_yaml(_USER_CONFIG_PATH)
+    except FileNotFoundError:
+        user_config = {}
+
+    # validate all parameters before setting anything
+    for key, value in kwargs.items():
+        if key not in default_config:
+            options = ', '.join(default_config)
+            raise ValueError(f'Trying to set invalid config key: {key!r}, possible options: {options}')  # noqa: E501
+
+    for key, value in kwargs.items():
+        if value is None:
+            user_config.pop(key, None)
+        else:
+            user_config[key] = value
+
+    with open(_USER_CONFIG_PATH, 'w') as user_config_file:
+        yaml.dump(user_config, user_config_file)

--- a/sleepecg/config.yml
+++ b/sleepecg/config.yml
@@ -1,0 +1,2 @@
+data_dir: ~/.sleepecg/datasets
+testdata_dir: ~/.sleepecg/testdata

--- a/sleepecg/globals.py
+++ b/sleepecg/globals.py
@@ -1,3 +1,0 @@
-"""Global configuration values."""
-
-DATA_DIR = '~/.sleepecg/datasets'

--- a/sleepecg/io/ecg_readers.py
+++ b/sleepecg/io/ecg_readers.py
@@ -50,7 +50,7 @@ class ECGRecord:
 
 
 def read_ltdb(
-    data_dir: Union[str, Path] = get_config('data_dir'),
+    data_dir: Optional[Union[str, Path]] = None,
     records_pattern: str = '*',
     offline: bool = False,
 ) -> Iterator[ECGRecord]:
@@ -60,7 +60,8 @@ def read_ltdb(
     Parameters
     ----------
     data_dir : str | pathlib.Path, optional
-        Directory where all datasets are stored, by default |DATA_DIR|
+        Directory where all datasets are stored. If `None` (default), the
+        value will be taken from the configuration.
     records_pattern : str, optional
         Glob-like pattern to select record IDs, by default `'*'`.
     offline : bool, optional
@@ -74,11 +75,13 @@ def read_ltdb(
         the ECG signal (`.ecg`), sampling frequency (`.fs`), annotated beat
         indices (`.annotations`), `.lead`, and `.id`.
     """
+    if data_dir is None:
+        data_dir = get_config('data_dir')
     yield from _read_mitbih(data_dir, 'ltdb', records_pattern, offline)
 
 
 def read_mitdb(
-    data_dir: Union[str, Path] = get_config('data_dir'),
+    data_dir: Optional[Union[str, Path]] = None,
     records_pattern: str = '*',
     offline: bool = False,
 ) -> Iterator[ECGRecord]:
@@ -88,7 +91,8 @@ def read_mitdb(
     Parameters
     ----------
     data_dir : str | pathlib.Path, optional
-        Directory where all datasets are stored, by default |DATA_DIR|
+        Directory where all datasets are stored. If `None` (default), the
+        value will be taken from the configuration.
     records_pattern : str, optional
         Glob-like pattern to select record IDs, by default `'*'`.
     offline : bool, optional
@@ -102,6 +106,8 @@ def read_mitdb(
         the ECG signal (`.ecg`), sampling frequency (`.fs`), annotated beat
         indices (`.annotations`), `.lead`, and `.id`.
     """
+    if data_dir is None:
+        data_dir = get_config('data_dir')
     yield from _read_mitbih(data_dir, 'mitdb', records_pattern, offline)
 
 
@@ -174,7 +180,7 @@ def _read_mitbih(
 
 
 def read_gudb(
-    data_dir: Union[str, Path] = get_config('data_dir'),
+    data_dir: Optional[Union[str, Path]] = None,
     offline: bool = False,
 ) -> Iterator[ECGRecord]:
     """
@@ -185,7 +191,8 @@ def read_gudb(
     Parameters
     ----------
     data_dir : str | pathlib.Path, optional
-        Directory where all datasets are stored, by default |DATA_DIR|
+        Directory where all datasets are stored. If `None` (default), the
+        value will be taken from the configuration.
     offline : bool, optional
         If `True`, only local files will be used (i.e. no files will be
         downloaded), by default `False`.
@@ -202,6 +209,9 @@ def read_gudb(
     DB_URL = 'https://berndporr.github.io/ECG-GUDB/experiment_data'
     EXPERIMENTS = ['sitting', 'maths', 'walking', 'hand_bike', 'jogging']
     FS = 250
+
+    if data_dir is None:
+        data_dir = get_config('data_dir')
 
     db_dir = Path(data_dir).expanduser() / 'gudb'
 

--- a/sleepecg/io/ecg_readers.py
+++ b/sleepecg/io/ecg_readers.py
@@ -12,7 +12,7 @@ import numpy as np
 import requests
 from tqdm import tqdm
 
-from ..globals import DATA_DIR
+from ..config import get_config
 from .physionet import download_physionet, list_physionet
 from .utils import download_file
 
@@ -50,7 +50,7 @@ class ECGRecord:
 
 
 def read_ltdb(
-    data_dir: Union[str, Path] = DATA_DIR,
+    data_dir: Union[str, Path] = get_config('data_dir'),
     records_pattern: str = '*',
     offline: bool = False,
 ) -> Iterator[ECGRecord]:
@@ -78,7 +78,7 @@ def read_ltdb(
 
 
 def read_mitdb(
-    data_dir: Union[str, Path] = DATA_DIR,
+    data_dir: Union[str, Path] = get_config('data_dir'),
     records_pattern: str = '*',
     offline: bool = False,
 ) -> Iterator[ECGRecord]:
@@ -174,7 +174,7 @@ def _read_mitbih(
 
 
 def read_gudb(
-    data_dir: Union[str, Path] = DATA_DIR,
+    data_dir: Union[str, Path] = get_config('data_dir'),
     offline: bool = False,
 ) -> Iterator[ECGRecord]:
     """

--- a/sleepecg/test/test_config.py
+++ b/sleepecg/test/test_config.py
@@ -4,21 +4,17 @@
 
 """Tests for the configuration interface."""
 
-from pathlib import Path
-
 import pytest
 
 import sleepecg.config
 from sleepecg import get_config, set_config
 
-_TESTCONFIG_PATH = '~/.sleepecg/testdata/testconfig.yml'
-
 
 @pytest.fixture(autouse=True)
-def temp_test_config():
+def temp_test_config(tmp_path):
     """Create, use and delete a temporary user config file for testing."""
     user_config_path_backup = sleepecg.config._USER_CONFIG_PATH
-    sleepecg.config._USER_CONFIG_PATH = Path(_TESTCONFIG_PATH).expanduser()
+    sleepecg.config._USER_CONFIG_PATH = tmp_path / 'testconfig.yml'
 
     yield
 

--- a/sleepecg/test/test_config.py
+++ b/sleepecg/test/test_config.py
@@ -1,0 +1,54 @@
+# Authors: Florian Hofer
+#
+# License: BSD (3-clause)
+
+"""Tests for the configuration interface."""
+
+from pathlib import Path
+
+import pytest
+
+import sleepecg.config
+from sleepecg import get_config, set_config
+
+_TESTCONFIG_PATH = '~/.sleepecg/testdata/testconfig.yml'
+
+
+@pytest.fixture(autouse=True)
+def temp_test_config():
+    """Create, use and delete a temporary user config file for testing."""
+    user_config_path_backup = sleepecg.config._USER_CONFIG_PATH
+    sleepecg.config._USER_CONFIG_PATH = Path(_TESTCONFIG_PATH).expanduser()
+
+    yield
+
+    if sleepecg.config._USER_CONFIG_PATH.is_file():
+        sleepecg.config._USER_CONFIG_PATH.unlink()
+    sleepecg.config._USER_CONFIG_PATH = user_config_path_backup
+
+
+def test_get_set_del_config():
+    """Test setting, getting and deleting a setting."""
+    assert get_config('data_dir') == '~/.sleepecg/datasets'
+    set_config(data_dir='some_dir')
+    assert get_config('data_dir') == 'some_dir'
+    set_config(data_dir=None)
+    assert get_config('data_dir') == '~/.sleepecg/datasets'
+
+
+def test_set_invalid_config():
+    """Test trying to set an invalid configuration key."""
+    with pytest.raises(ValueError):
+        set_config(invalid_key='some_value')
+
+
+def test_get_invalid_config():
+    """Test trying to get an invalid configuration key."""
+    with pytest.raises(ValueError):
+        get_config('invalid_key')
+
+
+def test_get_all_config():
+    """Test trying to get all configuration values as a dict."""
+    all_config = get_config()
+    assert isinstance(all_config, dict)

--- a/sleepecg/test/test_config.py
+++ b/sleepecg/test/test_config.py
@@ -21,8 +21,6 @@ def temp_test_config(tmp_path):
     yield
 
     # cleanup
-    if sleepecg.config._USER_CONFIG_PATH.is_file():
-        sleepecg.config._USER_CONFIG_PATH.unlink()
     sleepecg.config._USER_CONFIG_PATH = user_config_path_backup
 
 

--- a/sleepecg/test/test_config.py
+++ b/sleepecg/test/test_config.py
@@ -13,11 +13,14 @@ from sleepecg import get_config, set_config
 @pytest.fixture(autouse=True)
 def temp_test_config(tmp_path):
     """Create, use and delete a temporary user config file for testing."""
+    # setup
     user_config_path_backup = sleepecg.config._USER_CONFIG_PATH
     sleepecg.config._USER_CONFIG_PATH = tmp_path / 'testconfig.yml'
 
+    # execute test
     yield
 
+    # cleanup
     if sleepecg.config._USER_CONFIG_PATH.is_file():
         sleepecg.config._USER_CONFIG_PATH.unlink()
     sleepecg.config._USER_CONFIG_PATH = user_config_path_backup

--- a/sleepecg/test/test_config.py
+++ b/sleepecg/test/test_config.py
@@ -35,13 +35,13 @@ def test_get_set_del_config():
 
 def test_set_invalid_config():
     """Test trying to set an invalid configuration key."""
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='Trying to set invalid config key:'):
         set_config(invalid_key='some_value')
 
 
 def test_get_invalid_config():
     """Test trying to get an invalid configuration key."""
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='Trying to get invalid config key:'):
         get_config('invalid_key')
 
 

--- a/sleepecg/test/test_heartbeats.py
+++ b/sleepecg/test/test_heartbeats.py
@@ -7,7 +7,7 @@
 import numpy as np
 import pytest
 
-from sleepecg import compare_heartbeats, detect_heartbeats
+from sleepecg import compare_heartbeats, detect_heartbeats, get_config
 from sleepecg.io import read_mitdb
 
 
@@ -25,10 +25,9 @@ def test_compare_heartbeats():
 
 
 @pytest.fixture(scope='session')
-def mitdb_234_MLII(tmp_path_factory):
+def mitdb_234_MLII():
     """Fetch record for detector tests."""
-    tmpdir = tmp_path_factory.mktemp('data')
-    return next(read_mitdb(tmpdir, '234'))
+    return next(read_mitdb(get_config('testdata_dir'), '234'))
 
 
 @pytest.mark.parametrize('backend', ['c', 'numba', 'python'])


### PR DESCRIPTION
This adds the possibility to store and retrieve configuration values which are stored under `~/.sleepecg/config.yml`, with default values sourced from `site-packages/sleepecg/config.yml`. The module `globals` is made obsolete and removed.