### PR TITLE
Fix failing readthedocs build

### DIFF
--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -1,4 +1,0 @@
-myst-parser
-numpydoc
-pydata_sphinx_theme
-sphinx

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -4,13 +4,18 @@
 
 version: 2
 
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.7"
+
 sphinx:
   configuration: doc/source/conf.py
 
 python:
-  version: 3.7
   system_packages: true
   install:
-  - requirements: doc/requirements-doc.txt
-  - method: setuptools
+  - method: pip
     path: "."
+    extra_requirements:
+      - doc

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,12 @@ dev =
     sphinx>=4.1.0
     wfdb>=3.3.0
 
+doc =
+    myst-parser
+    numpydoc
+    pydata_sphinx_theme
+    sphinx
+
 
 [options.package_data]
 * = *.pyi


### PR DESCRIPTION
Building the docs on readthedocs is currently [failing](https://readthedocs.org/projects/sleepecg/builds/15421420/) because it attempts to install numpy 1.22.0rc1, which requires python 3.8. Using `pip` as the package installation method (instead of `setuptools`) and placing the doc requirements into an extras-section in `setup.cfg` (instead of `doc/requirements-doc.txt`) appears to fix that (see [this test build](https://readthedocs.org/projects/test-sleepecg/builds/15421560/)).