### PR TITLE
Execute example scripts with pytest

### DIFF
--- a/sleepecg/config.yml
+++ b/sleepecg/config.yml
@@ -1,2 +1,1 @@
 data_dir: ~/.sleepecg/datasets
-testdata_dir: ~/.sleepecg/testdata

--- a/sleepecg/test/test_examples.py
+++ b/sleepecg/test/test_examples.py
@@ -1,4 +1,3 @@
-# %%
 # Authors: Florian Hofer
 #
 # License: BSD (3-clause)

--- a/sleepecg/test/test_examples.py
+++ b/sleepecg/test/test_examples.py
@@ -1,0 +1,32 @@
+# Authors: Florian Hofer
+#
+# License: BSD (3-clause)
+
+"""Tests to make sure examples don't crash."""
+
+import runpy
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import pytest
+
+EXCLUDE = [
+    '*/benchmark/*',
+]
+
+examples_dir = (Path(__file__).parent / '../../examples').resolve()
+
+files_to_test = []
+for pyfile in examples_dir.rglob('*.py'):
+    for pattern in EXCLUDE:
+        if not pyfile.match(pattern):
+            files_to_test.append(pyfile)
+
+
+@pytest.mark.parametrize('script', files_to_test)
+def test_example(script, monkeypatch):
+    """Run all examples to make sure they don't crash."""
+    # Keep matplotlib from showing figures
+    monkeypatch.setattr(plt, 'show', lambda: None)
+
+    runpy.run_path(script)

--- a/sleepecg/test/test_examples.py
+++ b/sleepecg/test/test_examples.py
@@ -1,9 +1,11 @@
+# %%
 # Authors: Florian Hofer
 #
 # License: BSD (3-clause)
 
 """Tests to make sure examples don't crash."""
 
+import fnmatch
 import runpy
 from pathlib import Path
 
@@ -16,14 +18,12 @@ EXCLUDE = [
 
 examples_dir = (Path(__file__).parent / '../../examples').resolve()
 
-files_to_test = []
-for pyfile in examples_dir.rglob('*.py'):
-    for pattern in EXCLUDE:
-        if not pyfile.match(pattern):
-            files_to_test.append(pyfile)
+example_files = {str(f) for f in examples_dir.rglob('*.py')}
+for pattern in EXCLUDE:
+    example_files -= set(fnmatch.filter(example_files, pattern))
 
 
-@pytest.mark.parametrize('script', files_to_test)
+@pytest.mark.parametrize('script', example_files)
 def test_example(script, monkeypatch):
     """Run all examples to make sure they don't crash."""
     # Keep matplotlib from showing figures

--- a/sleepecg/test/test_heartbeats.py
+++ b/sleepecg/test/test_heartbeats.py
@@ -7,7 +7,7 @@
 import numpy as np
 import pytest
 
-from sleepecg import compare_heartbeats, detect_heartbeats, get_config
+from sleepecg import compare_heartbeats, detect_heartbeats
 from sleepecg.io import read_mitdb
 
 
@@ -27,7 +27,7 @@ def test_compare_heartbeats():
 @pytest.fixture(scope='session')
 def mitdb_234_MLII():
     """Fetch record for detector tests."""
-    return next(read_mitdb(get_config('testdata_dir'), '234'))
+    return next(read_mitdb(records_pattern='234'))
 
 
 @pytest.mark.parametrize('backend', ['c', 'numba', 'python'])

--- a/sleepecg/test/test_sleep_readers.py
+++ b/sleepecg/test/test_sleep_readers.py
@@ -12,7 +12,6 @@ import numpy as np
 import scipy.misc
 from pyedflib import highlevel
 
-from sleepecg import get_config
 from sleepecg.io import read_mesa
 from sleepecg.io.sleep_readers import SleepStage
 
@@ -97,14 +96,13 @@ def _create_dummy_mesa(data_dir: str, durations: List[float], random_state: int 
         _dummy_mesa_xml(f'{annotations_dir}/{record_id}-nsrr.xml', hours, random_state)
 
 
-def test_read_mesa():
+def test_read_mesa(tmp_path):
     """Basic sanity checks for records read via read_mesa."""
-    data_dir = get_config('testdata_dir')
     durations = [0.1, 0.2]  # hours
     valid_stages = {int(s) for s in SleepStage}
 
-    _create_dummy_mesa(data_dir=data_dir, durations=durations)
-    records = list(read_mesa(data_dir=data_dir, offline=True))
+    _create_dummy_mesa(data_dir=tmp_path, durations=durations)
+    records = list(read_mesa(data_dir=tmp_path, offline=True))
 
     assert len(records) == 2
 


### PR DESCRIPTION
To make sure the example scripts work... if an example should not be tested (e.g. because takes a long time, like the benchmark), it can be excluded by adding its name to `EXCLUDE` in `sleepecg/test/test_examples.py`.