### PR TITLE
Make public API exports less redundant

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ SleepECG adheres to [PEP 8](https://www.python.org/dev/peps/pep-0008/), with the
     - The closing parenthesis or bracket is indented at the same level as the starting line.
     ```python
     # Example
-    def download_file(
+    def _download_file(
         url: str,
         target_filepath: Path,
         checksum: Optional[str] = None,
@@ -66,6 +66,12 @@ SleepECG adheres to [PEP 8](https://www.python.org/dev/peps/pep-0008/), with the
         verbose: bool = False,
     ) -> None:
     ```
+
+
+## Public API
+- Every non-public member (i.e. every member not intended to be accessed by an end user) is prefixed with an underscore: `_`.
+- Modules export their public members explicitly (i.e. alphabetically list them in `__all__`). Otherwise their imports would be exported as well.
+- Inside a (sub-)package's `__init__.py`, `__all__` is _not_ set and module members are imported using `from .module import *`. This avoids listing member names multiple times.
 
 
 ## Documentation

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,6 +72,7 @@ max-line-length = 92
 max-doc-length = 75
 exclude =
     ./build/*
+per-file-ignores = __init__.py:F401,F403
 
 
 [isort]

--- a/sleepecg/__init__.py
+++ b/sleepecg/__init__.py
@@ -1,19 +1,8 @@
 """A package for sleep stage classification using ECG data."""
 
 from . import io
-from .config import get_config, set_config
-from .feature_extraction import extract_features, preprocess_rri
-from .heartbeats import compare_heartbeats, detect_heartbeats, rri_similarity
-
-__all__ = [
-    'io',
-    'detect_heartbeats',
-    'compare_heartbeats',
-    'rri_similarity',
-    'get_config',
-    'set_config',
-    'extract_features',
-    'preprocess_rri',
-]
+from .config import *
+from .feature_extraction import *
+from .heartbeats import *
 
 __version__ = '0.4.0-dev'

--- a/sleepecg/config.py
+++ b/sleepecg/config.py
@@ -14,6 +14,7 @@ __all__ = [
     'set_config',
 ]
 
+
 _DEFAULT_CONFIG_PATH = Path(__file__).parent / 'config.yml'
 _USER_CONFIG_PATH = Path('~/.sleepecg/config.yml').expanduser()
 

--- a/sleepecg/heartbeats.py
+++ b/sleepecg/heartbeats.py
@@ -25,7 +25,6 @@ try:
 except ImportError:
     _available_backends.remove('numba')
 
-
 __all__ = [
     'compare_heartbeats',
     'detect_heartbeats',

--- a/sleepecg/io/__init__.py
+++ b/sleepecg/io/__init__.py
@@ -1,14 +1,6 @@
 """Functions for downloading and reading datasets."""
 
-from .ecg_readers import read_gudb, read_ltdb, read_mitdb
-from .nsrr import download_nsrr, set_nsrr_token
-from .sleep_readers import read_mesa
-
-__all__ = [
-    'read_gudb',
-    'read_ltdb',
-    'read_mitdb',
-    'read_mesa',
-    'set_nsrr_token',
-    'download_nsrr',
-]
+from .ecg_readers import *
+from .nsrr import *
+from .physionet import *
+from .sleep_readers import *

--- a/sleepecg/io/ecg_readers.py
+++ b/sleepecg/io/ecg_readers.py
@@ -13,8 +13,8 @@ import requests
 from tqdm import tqdm
 
 from ..config import get_config
-from .physionet import download_physionet, list_physionet
-from .utils import download_file
+from .physionet import _list_physionet, download_physionet
+from .utils import _download_file
 
 __all__ = [
     'read_ltdb',
@@ -148,7 +148,7 @@ def _read_mitbih(
 
     data_dir = Path(data_dir).expanduser()
 
-    requested_records = list_physionet(data_dir, db_slug, pattern=records_pattern)
+    requested_records = _list_physionet(data_dir, db_slug, pattern=records_pattern)
 
     if not offline:
         download_physionet(
@@ -227,7 +227,7 @@ def read_gudb(
                     ecg_file_url = f'{DB_URL}/{experiment_subdir}/{tsv_filename}'
                     target_filepath = db_dir / experiment_subdir / tsv_filename
                     try:
-                        download_file(ecg_file_url, target_filepath)
+                        _download_file(ecg_file_url, target_filepath)
                     except requests.exceptions.HTTPError as error:
                         print(error)
             ecg_data = pd.read_csv(

--- a/sleepecg/io/physionet.py
+++ b/sleepecg/io/physionet.py
@@ -10,20 +10,20 @@ from typing import Dict, Iterable, List, Optional
 
 from tqdm import tqdm
 
-from .utils import download_file
+from .utils import _download_file
 
 __all__ = [
-    'list_physionet',
     'download_physionet',
 ]
 
-PHYSIONET_FILES_URL = 'https://physionet.org/files/'
-CHECKSUM_FILENAME = 'SHA256SUMS.txt'
-RECORDS_FILENAME = 'RECORDS'
-CHECKSUM_TYPE = 'sha256'
+
+_PHYSIONET_FILES_URL = 'https://physionet.org/files/'
+_CHECKSUM_FILENAME = 'SHA256SUMS.txt'
+_RECORDS_FILENAME = 'RECORDS'
+_CHECKSUM_TYPE = 'sha256'
 
 
-def list_physionet(
+def _list_physionet(
     data_dir: Path,
     db_slug: str,
     db_version: Optional[str] = '1.0.0',
@@ -53,12 +53,12 @@ def list_physionet(
     """
     data_dir = Path(data_dir)
 
-    records_filepath = data_dir / db_slug / RECORDS_FILENAME
-    records_url = f'{PHYSIONET_FILES_URL}/{db_slug}/{db_version}/{RECORDS_FILENAME}'
-    checksum = _get_physionet_checksums(data_dir, db_slug, db_version)[RECORDS_FILENAME]
+    records_filepath = data_dir / db_slug / _RECORDS_FILENAME
+    records_url = f'{_PHYSIONET_FILES_URL}/{db_slug}/{db_version}/{_RECORDS_FILENAME}'
+    checksum = _get_physionet_checksums(data_dir, db_slug, db_version)[_RECORDS_FILENAME]
 
     if not records_filepath.is_file():
-        download_file(records_url, records_filepath, checksum, CHECKSUM_TYPE)
+        _download_file(records_url, records_filepath, checksum, _CHECKSUM_TYPE)
 
     all_records = records_filepath.read_text().splitlines()
     return fnmatch.filter(all_records, pattern)
@@ -92,18 +92,18 @@ def download_physionet(
     """
     data_dir = Path(data_dir)
     checksums = _get_physionet_checksums(data_dir, db_slug, db_version)
-    db_url = f'{PHYSIONET_FILES_URL}/{db_slug}/{db_version}'
+    db_url = f'{_PHYSIONET_FILES_URL}/{db_slug}/{db_version}'
 
     for record_id in tqdm(requested_records, desc=f'Downloading {db_slug}'):
         for extension in extensions:
             if not extension.startswith('.'):
                 extension = '.' + extension
             filepath = (data_dir / db_slug / record_id).with_suffix(extension)
-            download_file(
+            _download_file(
                 f'{db_url}/{filepath.name}',
                 filepath,
                 checksums[filepath.name],
-                checksum_type=CHECKSUM_TYPE,
+                checksum_type=_CHECKSUM_TYPE,
             )
 
 
@@ -133,11 +133,11 @@ def _get_physionet_checksums(
     dict[str, str]
         Mapping of filenames to checksums.
     """
-    checksum_url = f'{PHYSIONET_FILES_URL}/{db_slug}/{db_version}/{CHECKSUM_FILENAME}'
-    checksum_filepath = data_dir / db_slug / CHECKSUM_FILENAME
+    checksum_url = f'{_PHYSIONET_FILES_URL}/{db_slug}/{db_version}/{_CHECKSUM_FILENAME}'
+    checksum_filepath = data_dir / db_slug / _CHECKSUM_FILENAME
 
     if not checksum_filepath.is_file():
-        download_file(checksum_url, checksum_filepath)
+        _download_file(checksum_url, checksum_filepath)
 
     checksums = {}
     for line in checksum_filepath.read_text().splitlines():

--- a/sleepecg/io/sleep_readers.py
+++ b/sleepecg/io/sleep_readers.py
@@ -15,15 +15,15 @@ import numpy as np
 
 from ..config import get_config
 from ..heartbeats import detect_heartbeats
-from .nsrr import get_nsrr_url, list_nsrr
-from .utils import download_file
+from .nsrr import _get_nsrr_url, _list_nsrr
+from .utils import _download_file
 
 __all__ = [
     'read_mesa',
 ]
 
 
-class SleepStage(IntEnum):
+class _SleepStage(IntEnum):
     """
     Mapping of AASM sleep stages to integers.
 
@@ -47,7 +47,7 @@ class SleepRecord:
     ----------
     sleep_stages : np.ndarray, optional
         Sleep stages according to AASM guidelines, stored as integers as
-        defined by `SleepStage`, by default `None`.
+        defined by `_SleepStage`, by default `None`.
     sleep_stage_duration : int, optional
         Duration of each sleep stage in seconds, by default `None`.
     id : str, optional
@@ -85,7 +85,7 @@ def _parse_nsrr_xml(xml_filepath: Path) -> _ParseNsrrXmlResult:
     -------
     sleep_stages : np.ndarray
         Sleep stages according to AASM guidelines, stored as integers as
-        defined by `SleepStage`.
+        defined by `_SleepStage`.
     sleep_stage_duration : int
         Duration of each sleep stage in seconds.
     recording_start_time : datetime.time
@@ -93,13 +93,13 @@ def _parse_nsrr_xml(xml_filepath: Path) -> _ParseNsrrXmlResult:
 
     """
     STAGE_MAPPING = {
-        'Wake|0': SleepStage.WAKE,
-        'Stage 1 sleep|1': SleepStage.N1,
-        'Stage 2 sleep|2': SleepStage.N2,
-        'Stage 3 sleep|3': SleepStage.N3,
-        'Stage 4 sleep|4': SleepStage.N3,
-        'REM sleep|5': SleepStage.REM,
-        'Unscored|9': SleepStage.UNDEFINED,
+        'Wake|0': _SleepStage.WAKE,
+        'Stage 1 sleep|1': _SleepStage.N1,
+        'Stage 2 sleep|2': _SleepStage.N2,
+        'Stage 3 sleep|3': _SleepStage.N3,
+        'Stage 4 sleep|4': _SleepStage.N3,
+        'REM sleep|5': _SleepStage.REM,
+        'Unscored|9': _SleepStage.UNDEFINED,
     }
 
     root = ElementTree.parse(xml_filepath).getroot()
@@ -183,7 +183,7 @@ def read_mesa(
         data_dir = get_config('data_dir')
 
     if not offline:
-        download_url = get_nsrr_url(DB_SLUG)
+        download_url = _get_nsrr_url(DB_SLUG)
 
     db_dir = Path(data_dir).expanduser() / DB_SLUG
     annotations_dir = db_dir / ANNOTATION_DIRNAME
@@ -195,7 +195,7 @@ def read_mesa(
 
     if not offline:
         checksums = {}
-        xml_files = list_nsrr(
+        xml_files = _list_nsrr(
             DB_SLUG,
             ANNOTATION_DIRNAME,
             f'mesa-sleep-{records_pattern}-nsrr.xml',
@@ -204,7 +204,7 @@ def read_mesa(
         checksums.update(xml_files)
         requested_records = [Path(file).stem[:-5] for file, _ in xml_files]
 
-        edf_files = list_nsrr(
+        edf_files = _list_nsrr(
             DB_SLUG,
             EDF_DIRNAME,
             f'mesa-sleep-{records_pattern}.edf',
@@ -226,7 +226,7 @@ def read_mesa(
             edf_filepath = db_dir / edf_filename
             edf_was_available = edf_filepath.is_file()
             if not offline:
-                download_file(
+                _download_file(
                     download_url + edf_filename,
                     edf_filepath,
                     checksums[edf_filename],
@@ -246,7 +246,7 @@ def read_mesa(
         xml_filename = ANNOTATION_DIRNAME + f'/{record_id}-nsrr.xml'
         xml_filepath = db_dir / xml_filename
         if not offline:
-            download_file(
+            _download_file(
                 download_url + xml_filename,
                 xml_filepath,
                 checksums[xml_filename],

--- a/sleepecg/io/utils.py
+++ b/sleepecg/io/utils.py
@@ -10,10 +10,6 @@ from typing import Optional
 
 import requests
 
-__all__ = [
-    'download_file',
-]
-
 _HASH_FUNCTIONS = {
     'md5': hashlib.md5,
     'sha256': hashlib.sha256,
@@ -46,7 +42,7 @@ def _calculate_checksum(filepath: Path, checksum_type: str) -> str:
     return computed_hash.hexdigest()
 
 
-def download_file(
+def _download_file(
     url: str,
     target_filepath: Path,
     checksum: Optional[str] = None,

--- a/sleepecg/test/test_sleep_readers.py
+++ b/sleepecg/test/test_sleep_readers.py
@@ -13,7 +13,7 @@ import scipy.misc
 from pyedflib import highlevel
 
 from sleepecg.io import read_mesa
-from sleepecg.io.sleep_readers import SleepStage
+from sleepecg.io.sleep_readers import _SleepStage
 
 
 def _dummy_mesa_edf(filename: str, hours: float):
@@ -99,7 +99,7 @@ def _create_dummy_mesa(data_dir: str, durations: List[float], random_state: int 
 def test_read_mesa(tmp_path):
     """Basic sanity checks for records read via read_mesa."""
     durations = [0.1, 0.2]  # hours
-    valid_stages = {int(s) for s in SleepStage}
+    valid_stages = {int(s) for s in _SleepStage}
 
     _create_dummy_mesa(data_dir=tmp_path, durations=durations)
     records = list(read_mesa(data_dir=tmp_path, offline=True))


### PR DESCRIPTION
To avoid repeating module member names in `__init__.py` files, I'd suggest the following guidelines:
- Every non-public member (i.e. every member not intended to be accessed by an end user) is prefixed with an underscore: `_`.
- Modules export their public members explicitly (i.e. alphabetically list them in `__all__`). Otherwise their imports would be exported as well.
- Inside a (sub-)package's `__init__.py`, `__all__` is _not_ set and module members are imported using `from .module import *`. This avoids listing member names multiple times.

Notes:
- `SleepRecord` and `ECGRecord` will usually not be instantiated by a user, but should be explained in the docs as they are yielded by public generators. Only public members (i.e. those not starting with an underscore) are listed by Sphinx' autosummary. Therefore these two need to have a public name, but are not exported.
- We could have tests to make sure these guidelines are followed, WDYT?