### PR TITLE
Add reader for SHHS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add function for reading data from the [MESA](https://sleepdata.org/datasets/mesa) datasets ([#28](https://github.com/cbrnr/sleepecg/pull/28) by [Florian Hofer](https://github.com/hofaflo))
 - Add heart rate variability (HRV) feature extraction ([#36](https://github.com/cbrnr/sleepecg/pull/36) by [Florian Hofer](https://github.com/hofaflo))
 - Add reader function for [SLPDB](https://physionet.org/content/slpdb) ([#47](https://github.com/cbrnr/sleepecg/pull/47)) by [Florian Hofer](https://github.com/hofaflo))
+- Add reader function for [SHHS](https://sleepdata.org/datasets/shhs) ([#48](https://github.com/cbrnr/sleepecg/pull/48)) by [Florian Hofer](https://github.com/hofaflo))
 
 ## [0.3.0] - 2021-08-25
 ### Added

--- a/sleepecg/io/__init__.py
+++ b/sleepecg/io/__init__.py
@@ -3,4 +3,4 @@
 from .ecg_readers import read_gudb, read_ltdb, read_mitdb
 from .nsrr import download_nsrr, set_nsrr_token
 from .physionet import download_physionet
-from .sleep_readers import read_mesa, read_slpdb
+from .sleep_readers import read_mesa, read_shhs, read_slpdb

--- a/sleepecg/io/sleep_readers.py
+++ b/sleepecg/io/sleep_readers.py
@@ -15,9 +15,8 @@ import numpy as np
 
 from ..config import get_config
 from ..heartbeats import detect_heartbeats
-from .nsrr import _get_nsrr_url, _list_nsrr
+from .nsrr import _download_nsrr_file, _get_nsrr_url, _list_nsrr
 from .physionet import _list_physionet, download_physionet
-from .utils import _download_file
 
 
 class SleepStage(IntEnum):
@@ -223,11 +222,10 @@ def read_mesa(
             edf_filepath = db_dir / edf_filename
             edf_was_available = edf_filepath.is_file()
             if not offline:
-                _download_file(
+                _download_nsrr_file(
                     download_url + edf_filename,
                     edf_filepath,
                     checksums[edf_filename],
-                    'md5',
                 )
 
             rec = read_raw_edf(edf_filepath, verbose=False)
@@ -243,11 +241,10 @@ def read_mesa(
         xml_filename = ANNOTATION_DIRNAME + f'/{record_id}-nsrr.xml'
         xml_filepath = db_dir / xml_filename
         if not offline:
-            _download_file(
+            _download_nsrr_file(
                 download_url + xml_filename,
                 xml_filepath,
                 checksums[xml_filename],
-                'md5',
             )
 
         parsed_xml = _parse_nsrr_xml(xml_filepath)
@@ -453,11 +450,10 @@ def read_shhs(
             edf_filepath = db_dir / edf_filename
             edf_was_available = edf_filepath.is_file()
             if not offline:
-                _download_file(
+                _download_nsrr_file(
                     download_url + edf_filename,
                     edf_filepath,
                     checksums[edf_filename],
-                    'md5',
                 )
 
             rec = read_raw_edf(edf_filepath, verbose=False)
@@ -475,11 +471,10 @@ def read_shhs(
         xml_filename = ANNOTATION_DIRNAME + f'/{record_id}-nsrr.xml'
         xml_filepath = db_dir / xml_filename
         if not offline:
-            _download_file(
+            _download_nsrr_file(
                 download_url + xml_filename,
                 xml_filepath,
                 checksums[xml_filename],
-                'md5',
             )
 
         parsed_xml = _parse_nsrr_xml(xml_filepath)

--- a/sleepecg/io/sleep_readers.py
+++ b/sleepecg/io/sleep_readers.py
@@ -359,3 +359,135 @@ def read_slpdb(
             recording_start_time=start_time,
             heartbeat_times=heartbeat_times,
         )
+
+
+def read_shhs(
+    data_dir: Optional[Union[str, Path]] = None,
+    records_pattern: str = '*',
+    use_cached_heartbeats: bool = True,
+    offline: bool = False,
+    keep_edfs: bool = False,
+) -> Iterator[SleepRecord]:
+    """
+    Lazily read records from SHHS (https://sleepdata.org/datasets/shhs).
+
+    Each SHHS record consists of an `.edf` file containing raw
+    polysomnography data and an `.xml` file containing annotated events.
+    Since the entire SHHS dataset requires about 356 GB of disk space,
+    `.edf` files can be deleted after heartbeat times have been extracted.
+    Heartbeat times are cached in an `.npy` file in
+    `<data_dir>/shhs/preprocessed/heartbeats`.
+
+    Parameters
+    ----------
+    data_dir : str | pathlib.Path, optional
+        Directory where all datasets are stored. If `None` (default), the
+        value will be taken from the configuration.
+    records_pattern : str, optional
+         Glob-like pattern to select record IDs, by default `'*'`.
+    use_cached_heartbeats : bool, optional
+        If `True`, get heartbeat times directly from the cached `.npy`
+        file, so `.edf` files are only downloaded for records which have
+        not yet been preprocessed. By default `True`.
+    offline : bool, optional
+        If `True`, search for local files only instead of using the NSRR
+        API, by default `False`.
+    keep_edfs : bool, optional
+        If `False`, remove `.edf` after heartbeat detection, by default
+        `False`.
+
+    Yields
+    ------
+    SleepRecord
+        Each element in the generator is a :class:`SleepRecord`.
+    """
+    from mne.io import read_raw_edf
+
+    DB_SLUG = 'shhs'
+    ANNOTATION_DIRNAME = 'polysomnography/annotations-events-nsrr'
+    EDF_DIRNAME = 'polysomnography/edfs'
+    HEARTBEATS_DIRNAME = 'preprocessed/heartbeats'
+
+    if data_dir is None:
+        data_dir = get_config('data_dir')
+
+    if not offline:
+        download_url = _get_nsrr_url(DB_SLUG)
+
+    db_dir = Path(data_dir).expanduser() / DB_SLUG
+    annotations_dir = db_dir / ANNOTATION_DIRNAME
+    edf_dir = db_dir / EDF_DIRNAME
+    heartbeats_dir = db_dir / HEARTBEATS_DIRNAME
+
+    for directory in (annotations_dir, edf_dir, heartbeats_dir):
+        directory.mkdir(parents=True, exist_ok=True)
+
+    if not offline:
+        checksums = {}
+        xml_files = _list_nsrr(
+            DB_SLUG,
+            ANNOTATION_DIRNAME,
+            f'{records_pattern}-nsrr.xml',
+            shallow=False,
+        )
+        checksums.update(xml_files)
+        requested_records = [file[-27:-9] for file, _ in xml_files]
+
+        edf_files = _list_nsrr(
+            DB_SLUG,
+            EDF_DIRNAME,
+            f'{records_pattern}.edf',
+            shallow=False,
+        )
+        checksums.update(edf_files)
+    else:
+        xml_files = sorted(annotations_dir.rglob(f'{records_pattern}-nsrr.xml'))
+        requested_records = [str(file)[-27:-9] for file in xml_files]
+
+    for record_id in requested_records:
+        heartbeats_file = heartbeats_dir / f'{record_id}.npy'
+        if use_cached_heartbeats and heartbeats_file.is_file():
+            heartbeat_times = np.load(heartbeats_file)
+        else:
+            edf_filename = EDF_DIRNAME + f'/{record_id}.edf'
+            edf_filepath = db_dir / edf_filename
+            edf_was_available = edf_filepath.is_file()
+            if not offline:
+                _download_file(
+                    download_url + edf_filename,
+                    edf_filepath,
+                    checksums[edf_filename],
+                    'md5',
+                )
+
+            rec = read_raw_edf(edf_filepath, verbose=False)
+            ecg = rec.get_data('EKG').ravel()
+            fs = rec.info['sfreq']
+            heartbeat_indices = detect_heartbeats(ecg, fs)
+            heartbeat_times = heartbeat_indices / fs
+
+            heartbeats_file.parent.mkdir(parents=True, exist_ok=True)
+            np.save(heartbeats_file, heartbeat_times)
+
+            if not edf_was_available and not keep_edfs:
+                edf_filepath.unlink()
+
+        xml_filename = ANNOTATION_DIRNAME + f'/{record_id}-nsrr.xml'
+        xml_filepath = db_dir / xml_filename
+        if not offline:
+            _download_file(
+                download_url + xml_filename,
+                xml_filepath,
+                checksums[xml_filename],
+                'md5',
+            )
+
+        parsed_xml = _parse_nsrr_xml(xml_filepath)
+
+        yield SleepRecord(
+            sleep_stages=parsed_xml.sleep_stages,
+            sleep_stage_duration=parsed_xml.sleep_stage_duration,
+            id=record_id[6:],  # remove subdirectory
+            recording_start_time=parsed_xml.recording_start_time,
+            heartbeat_times=heartbeat_times,
+        )

--- a/sleepecg/io/sleep_readers.py
+++ b/sleepecg/io/sleep_readers.py
@@ -457,7 +457,7 @@ def read_shhs(
                 )
 
             rec = read_raw_edf(edf_filepath, verbose=False)
-            ecg = rec.get_data('EKG').ravel()
+            ecg = rec.get_data('ECG').ravel()
             fs = rec.info['sfreq']
             heartbeat_indices = detect_heartbeats(ecg, fs)
             heartbeat_times = heartbeat_indices / fs

--- a/sleepecg/test/test_sleep_readers.py
+++ b/sleepecg/test/test_sleep_readers.py
@@ -17,12 +17,12 @@ from sleepecg.io import read_mesa, read_shhs, read_slpdb
 from sleepecg.io.sleep_readers import SleepStage
 
 
-def _dummy_nsrr_edf(filename: str, hours: float):
+def _dummy_nsrr_edf(filename: str, hours: float, ecg_channel: str):
     ECG_FS = 360
     ecg_5_min = scipy.misc.electrocardiogram()
     seconds = int(hours * 60 * 60)
     ecg = np.tile(ecg_5_min, int(np.ceil(seconds / 300)))[np.newaxis, :seconds * ECG_FS]
-    signal_headers = highlevel.make_signal_headers(['EKG'], sample_frequency=ECG_FS)
+    signal_headers = highlevel.make_signal_headers([ecg_channel], sample_frequency=ECG_FS)
     with warnings.catch_warnings():
         warnings.filterwarnings('ignore')
         highlevel.write_edf(filename, ecg, signal_headers)
@@ -93,7 +93,7 @@ def _create_dummy_mesa(data_dir: str, durations: List[float], random_state: int 
 
     for i, hours in enumerate(durations):
         record_id = f'mesa-sleep-dummy-{i:04}'
-        _dummy_nsrr_edf(f'{edf_dir}/{record_id}.edf', hours)
+        _dummy_nsrr_edf(f'{edf_dir}/{record_id}.edf', hours, ecg_channel='EKG')
         _dummy_nsrr_xml(f'{annotations_dir}/{record_id}-nsrr.xml', hours, random_state)
 
 
@@ -113,7 +113,7 @@ def _create_dummy_shhs(data_dir: str, durations: List[float], random_state: int 
     for i, hours in enumerate(durations):
         for visit in ('shhs1', 'shhs2'):
             record_id = f'{visit}/{visit}-20{i:04}'
-            _dummy_nsrr_edf(f'{edf_dir}/{record_id}.edf', hours)
+            _dummy_nsrr_edf(f'{edf_dir}/{record_id}.edf', hours, ecg_channel='ECG')
             _dummy_nsrr_xml(f'{annotations_dir}/{record_id}-nsrr.xml', hours, random_state)
 
 

--- a/sleepecg/test/test_sleep_readers.py
+++ b/sleepecg/test/test_sleep_readers.py
@@ -13,11 +13,11 @@ import numpy as np
 import scipy.misc
 from pyedflib import highlevel
 
-from sleepecg.io import read_mesa, read_slpdb
+from sleepecg.io import read_mesa, read_shhs, read_slpdb
 from sleepecg.io.sleep_readers import SleepStage
 
 
-def _dummy_mesa_edf(filename: str, hours: float):
+def _dummy_nsrr_edf(filename: str, hours: float):
     ECG_FS = 360
     ecg_5_min = scipy.misc.electrocardiogram()
     seconds = int(hours * 60 * 60)
@@ -28,7 +28,7 @@ def _dummy_mesa_edf(filename: str, hours: float):
         highlevel.write_edf(filename, ecg, signal_headers)
 
 
-def _dummy_mesa_xml(filename: str, hours: float, random_state: int):
+def _dummy_nsrr_xml(filename: str, hours: float, random_state: int):
     EPOCH_LENGTH = 30
     STAGES = [
         'Wake|0',
@@ -93,8 +93,28 @@ def _create_dummy_mesa(data_dir: str, durations: List[float], random_state: int 
 
     for i, hours in enumerate(durations):
         record_id = f'mesa-sleep-dummy-{i:04}'
-        _dummy_mesa_edf(f'{edf_dir}/{record_id}.edf', hours)
-        _dummy_mesa_xml(f'{annotations_dir}/{record_id}-nsrr.xml', hours, random_state)
+        _dummy_nsrr_edf(f'{edf_dir}/{record_id}.edf', hours)
+        _dummy_nsrr_xml(f'{annotations_dir}/{record_id}-nsrr.xml', hours, random_state)
+
+
+def _create_dummy_shhs(data_dir: str, durations: List[float], random_state: int = 42):
+    DB_SLUG = 'shhs'
+    ANNOTATION_DIRNAME = 'polysomnography/annotations-events-nsrr'
+    EDF_DIRNAME = 'polysomnography/edfs'
+
+    db_dir = Path(data_dir).expanduser() / DB_SLUG
+    annotations_dir = db_dir / ANNOTATION_DIRNAME
+    edf_dir = db_dir / EDF_DIRNAME
+
+    for directory in (annotations_dir, edf_dir):
+        for visit in ('shhs1', 'shhs2'):
+            (directory / visit).mkdir(parents=True, exist_ok=True)
+
+    for i, hours in enumerate(durations):
+        for visit in ('shhs1', 'shhs2'):
+            record_id = f'{visit}/{visit}-20{i:04}'
+            _dummy_nsrr_edf(f'{edf_dir}/{record_id}.edf', hours)
+            _dummy_nsrr_xml(f'{annotations_dir}/{record_id}-nsrr.xml', hours, random_state)
 
 
 def test_read_mesa(tmp_path):
@@ -106,6 +126,21 @@ def test_read_mesa(tmp_path):
     records = list(read_mesa(data_dir=tmp_path, offline=True))
 
     assert len(records) == 2
+
+    for rec in records:
+        assert rec.sleep_stage_duration == 30
+        assert set(rec.sleep_stages) - valid_stages == set()
+
+
+def test_read_shhs(tmp_path):
+    """Basic sanity checks for records read via read_shhs."""
+    durations = [0.1, 0.2]  # hours
+    valid_stages = {int(s) for s in SleepStage}
+
+    _create_dummy_shhs(data_dir=tmp_path, durations=durations)
+    records = list(read_shhs(data_dir=tmp_path, offline=True))
+
+    assert len(records) == 4
 
     for rec in records:
         assert rec.sleep_stage_duration == 30


### PR DESCRIPTION
[SHHS](https://sleepdata.org/datasets/shhs)

This is pretty similar to `read_mesa`, except for the following differences:
- SHHS is grouped into two "visits" (there are two recorded nights for some participants), therefore there is an additional directory level (shhs1/shhs2).
- For MESA the ECG channel name is "EKG", for SHHS it's "ECG".
- SHHS does not include actigraphy data (while `read_mesa` doesn't read that data yet, this is planned).

Due to the similarity, large parts of `read_mesa` and `read_shhs` could be put into a new function. I'd like to postpone refactoring this until `read_mesa` handles actigraphy data and both functions handle metadata.