### PR TITLE
Skip test workflow on doc-only changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
       - main
   pull_request:
     paths-ignore:
-      - 'docs/**'
+      - 'doc/**'
   workflow_dispatch:
     # allow manual runs on branches without a PR
 


### PR DESCRIPTION
In case a commit/PR only changes files in `doc`, the build/test workflow doesn't need to run. This was already intended, but didn't happen due to a typo.