### PR TITLE
Export `sleepecg.io` members to main package 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Add reader function for [SLPDB](https://physionet.org/content/slpdb) ([#47](https://github.com/cbrnr/sleepecg/pull/47)) by [Florian Hofer](https://github.com/hofaflo))
 - Add reader function for [SHHS](https://sleepdata.org/datasets/shhs) ([#48](https://github.com/cbrnr/sleepecg/pull/48)) by [Florian Hofer](https://github.com/hofaflo))
 
+### Changed
+- Export members of `sleepecg.io` to main package ([#56](https://github.com/cbrnr/sleepecg/pull/56) by [Florian Hofer](https://github.com/hofaflo))
+
 ## [0.3.0] - 2021-08-25
 ### Added
 - Example containing code used for benchmarks ([#22](https://github.com/cbrnr/sleepecg/pull/22) by [Florian Hofer](https://github.com/hofaflo))

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -13,15 +13,15 @@ See :ref:`Datasets <datasets>` for information about the available datasets and 
    :toctree: generated/
    :nosignatures:
 
-   io.download_nsrr
-   io.download_physionet
-   io.read_gudb
-   io.read_ltdb
-   io.read_mesa
-   io.read_mitdb
-   io.read_shhs
-   io.read_slpdb
-   io.set_nsrr_token
+   download_nsrr
+   download_physionet
+   read_gudb
+   read_ltdb
+   read_mesa
+   read_mitdb
+   read_shhs
+   read_slpdb
+   set_nsrr_token
 
 
 Feature extraction

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -22,6 +22,9 @@ See :ref:`Datasets <datasets>` for information about the available datasets and 
    read_shhs
    read_slpdb
    set_nsrr_token
+   ECGRecord
+   SleepRecord
+   SleepStage
 
 
 Feature extraction

--- a/doc/source/datasets.md
+++ b/doc/source/datasets.md
@@ -5,17 +5,17 @@ SleepECG provides reader functions for various datasets. All required files will
 ## Sleep readers
 |Reader|Dataset name|Annotated records|Raw data size|Access|
 |-|-|-|-|-|
-|[read_mesa](./generated/sleepecg.io.read_mesa)|[Multi-Ethnic Study of Atherosclerosis](https://sleepdata.org/datasets/mesa/)|2056|385 GB|[request](https://sleepdata.org/data/requests/mesa/start)|
-|[read_shhs](./generated/sleepecg.io.read_shhs)|[Sleep Heart Health Study](https://sleepdata.org/datasets/mesa/)|8444|356 GB|[request](https://sleepdata.org/data/requests/shhs/start)|
-|[read_slpdb](./generated/sleepecg.io.read_slpdb)|[MIT-BIH Polysomnographic Database](https://physionet.org/content/slpdb)|18|632 MB|open|
+|[read_mesa](./generated/sleepecg.read_mesa)|[Multi-Ethnic Study of Atherosclerosis](https://sleepdata.org/datasets/mesa/)|2056|385 GB|[request](https://sleepdata.org/data/requests/mesa/start)|
+|[read_shhs](./generated/sleepecg.read_shhs)|[Sleep Heart Health Study](https://sleepdata.org/datasets/mesa/)|8444|356 GB|[request](https://sleepdata.org/data/requests/shhs/start)|
+|[read_slpdb](./generated/sleepecg.read_slpdb)|[MIT-BIH Polysomnographic Database](https://physionet.org/content/slpdb)|18|632 MB|open|
 
 
 ## ECG readers
 |Reader|Dataset name|Records|Signals|Raw data size|
 |-|-|-|-|-|
-|[read_gudb](./generated/sleepecg.io.read_gudb)|[Glasgow University ECG database ](https://berndporr.github.io/ECG-GUDB/)|335|335|550 MB|
-|[read_ltdb](./generated/sleepecg.io.read_ltdb)|[MIT-BIH Long-Term ECG Database](https://physionet.org/content/ltdb)|7|15|205 MB|
-|[read_mitdb](./generated/sleepecg.io.read_mitdb)|[MIT-BIH Arrhythmia Database](https://physionet.org/content/mitdb)|48|96|98.5 MB|
+|[read_gudb](./generated/sleepecg.read_gudb)|[Glasgow University ECG database ](https://berndporr.github.io/ECG-GUDB/)|335|335|550 MB|
+|[read_ltdb](./generated/sleepecg.read_ltdb)|[MIT-BIH Long-Term ECG Database](https://physionet.org/content/ltdb)|7|15|205 MB|
+|[read_mitdb](./generated/sleepecg.read_mitdb)|[MIT-BIH Arrhythmia Database](https://physionet.org/content/mitdb)|48|96|98.5 MB|
 
 
 ## NSRR data access
@@ -32,7 +32,7 @@ To gain access to a dataset provided by the [NSRR](https://sleepdata.org), compl
 
 The code below shows how to read all records in the [MESA](https://sleepdata.org/datasets/mesa) dataset with SleepECG:
 ```python
-from sleepecg.io import read_mesa, set_nsrr_token
+from sleepecg import read_mesa, set_nsrr_token
 
 set_nsrr_token('<your-download-token-here>')
 mesa = read_mesa()  # note that this is a generator
@@ -40,7 +40,7 @@ mesa = read_mesa()  # note that this is a generator
 
 You can also select a subset of records from a dataset. This example will download and read all records having IDs starting with `00` (i.e. records `0001`-`0099`):
 ```python
-from sleepecg.io import read_mesa, set_nsrr_token
+from sleepecg import read_mesa, set_nsrr_token
 
 set_nsrr_token('<your-download-token-here>')
 mesa = read_mesa(records_pattern='00*')  # note that this is a generator
@@ -48,7 +48,7 @@ mesa = read_mesa(records_pattern='00*')  # note that this is a generator
 
 If you just want to download NSRR data (like with the [NSRR Ruby Gem](https://github.com/nsrr/nsrr-gem)), use the workflow below. The example downloads all files within [`mesa/polysomnography/edfs`](https://sleepdata.org/datasets/mesa/files/polysomnography/edfs) matching `*-00*` to a local folder `./datasets` (subfolders are created to preserve the dataset's directory structure).
 ```python
-from sleepecg.io import download_nsrr, set_nsrr_token
+from sleepecg import download_nsrr, set_nsrr_token
 
 set_nsrr_token('<your-download-token-here>')
 download_nsrr(

--- a/examples/benchmark/utils.py
+++ b/examples/benchmark/utils.py
@@ -39,9 +39,9 @@ def reader_dispatch(data_dir: str, db_slug: str) -> Iterator[ECGRecord]:
         indices (`.annotations`), `.lead`, and `.id`.
     """
     readers = {
-        'gudb': sleepecg.io.read_gudb,
-        'ltdb': sleepecg.io.read_ltdb,
-        'mitdb': sleepecg.io.read_mitdb,
+        'gudb': sleepecg.read_gudb,
+        'ltdb': sleepecg.read_ltdb,
+        'mitdb': sleepecg.read_mitdb,
     }
     if db_slug not in readers:
         raise ValueError(f'Invalid db_slug: {db_slug}')

--- a/examples/feature_extraction.py
+++ b/examples/feature_extraction.py
@@ -1,8 +1,7 @@
 # %%
 import numpy as np
 
-from sleepecg import extract_features
-from sleepecg.io.sleep_readers import SleepRecord
+from sleepecg import SleepRecord, extract_features
 
 # Generate dummy data while we don't have reader functions for sleep data
 recording_hours = 8

--- a/examples/heartbeat_detection.py
+++ b/examples/heartbeat_detection.py
@@ -2,8 +2,7 @@
 import matplotlib.pyplot as plt
 import numpy as np
 
-from sleepecg import compare_heartbeats, detect_heartbeats
-from sleepecg.io import read_mitdb
+from sleepecg import compare_heartbeats, detect_heartbeats, read_mitdb
 
 # %% Download and read data, run detector
 record = list(read_mitdb(records_pattern='234'))[1]

--- a/sleepecg/__init__.py
+++ b/sleepecg/__init__.py
@@ -1,8 +1,8 @@
 """A package for sleep stage classification using ECG data."""
 
-from . import io
 from .config import get_config, set_config
 from .feature_extraction import extract_features, preprocess_rri
 from .heartbeats import compare_heartbeats, detect_heartbeats, rri_similarity
+from .io import *  # noqa: F403
 
 __version__ = '0.4.0-dev'

--- a/sleepecg/feature_extraction.py
+++ b/sleepecg/feature_extraction.py
@@ -458,7 +458,7 @@ def extract_features(
     ----------
     records : Iterable[SleepRecord]
         An iterable of `SleepRecord` objects, as yielded by the various
-        reader functions in `sleepecg.io`.
+        reader functions in SleepECG.
     lookback : int, optional
         Backward extension of the analysis window from each sleep stage
         time in seconds, by default `0`.

--- a/sleepecg/io/__init__.py
+++ b/sleepecg/io/__init__.py
@@ -1,6 +1,6 @@
 """Functions for downloading and reading datasets."""
 
-from .ecg_readers import read_gudb, read_ltdb, read_mitdb
+from .ecg_readers import ECGRecord, read_gudb, read_ltdb, read_mitdb
 from .nsrr import download_nsrr, set_nsrr_token
 from .physionet import download_physionet
-from .sleep_readers import read_mesa, read_shhs, read_slpdb
+from .sleep_readers import SleepRecord, SleepStage, read_mesa, read_shhs, read_slpdb

--- a/sleepecg/io/nsrr.py
+++ b/sleepecg/io/nsrr.py
@@ -63,7 +63,7 @@ def _get_nsrr_url(db_slug: str) -> str:
         The download URL.
     """
     if _nsrr_token is None:
-        raise RuntimeError('NSRR token not set, use `sleepecg.io.set_nsrr_token(<token>)`!')
+        raise RuntimeError('NSRR token not set, use `sleepecg.set_nsrr_token(<token>)`!')
     return f'https://sleepdata.org/datasets/{db_slug}/files/a/{_nsrr_token}/m/sleepecg/'
 
 

--- a/sleepecg/io/sleep_readers.py
+++ b/sleepecg/io/sleep_readers.py
@@ -43,7 +43,7 @@ class SleepRecord:
     ----------
     sleep_stages : np.ndarray, optional
         Sleep stages according to AASM guidelines, stored as integers as
-        defined by `SleepStage`, by default `None`.
+        defined by :class:`SleepStage`, by default `None`.
     sleep_stage_duration : int, optional
         Duration of each sleep stage in seconds, by default `None`.
     id : str, optional
@@ -81,7 +81,7 @@ def _parse_nsrr_xml(xml_filepath: Path) -> _ParseNsrrXmlResult:
     -------
     sleep_stages : np.ndarray
         Sleep stages according to AASM guidelines, stored as integers as
-        defined by `SleepStage`.
+        defined by :class:`SleepStage`.
     sleep_stage_duration : int
         Duration of each sleep stage in seconds.
     recording_start_time : datetime.time

--- a/sleepecg/test/test_heartbeats.py
+++ b/sleepecg/test/test_heartbeats.py
@@ -7,8 +7,7 @@
 import numpy as np
 import pytest
 
-from sleepecg import compare_heartbeats, detect_heartbeats
-from sleepecg.io import read_mitdb
+from sleepecg import compare_heartbeats, detect_heartbeats, read_mitdb
 
 
 def test_compare_heartbeats():

--- a/sleepecg/test/test_sleep_readers.py
+++ b/sleepecg/test/test_sleep_readers.py
@@ -13,7 +13,7 @@ import numpy as np
 import scipy.misc
 from pyedflib import highlevel
 
-from sleepecg.io import read_mesa, read_shhs, read_slpdb
+from sleepecg import read_mesa, read_shhs, read_slpdb
 from sleepecg.io.sleep_readers import SleepStage
 
 

--- a/sleepecg/test/test_sleep_readers.py
+++ b/sleepecg/test/test_sleep_readers.py
@@ -13,8 +13,7 @@ import numpy as np
 import scipy.misc
 from pyedflib import highlevel
 
-from sleepecg import read_mesa, read_shhs, read_slpdb
-from sleepecg.io.sleep_readers import SleepStage
+from sleepecg import SleepStage, read_mesa, read_shhs, read_slpdb
 
 
 def _dummy_nsrr_edf(filename: str, hours: float, ecg_channel: str):


### PR DESCRIPTION
To avoid situations like this:

```python
from sleepecg import extract_features
from sleepecg.io import read_mesa
```

I'd like to reduce the API to a single level, so one can do this:

```python
from sleepecg import extract_features, read_mesa
```

Also, to have `SleepRecord`, `SleepStage` and `ECGRecord` included and correctly linked in the docs, they are exported as well.