### PR TITLE
Warn about joblib only if `n_jobs!=1`

### DIFF
--- a/sleepecg/utils.py
+++ b/sleepecg/utils.py
@@ -66,7 +66,8 @@ def _parallel(
     try:
         from joblib import Parallel, delayed
     except ImportError:
-        warnings.warn('joblib not installed, cannot run in parallel.')
+        if n_jobs != 1:
+            warnings.warn('joblib not installed, cannot run in parallel.')
         return [function(x, *args, **kwargs) for x in iterable]
 
     return Parallel(n_jobs=n_jobs)(


### PR DESCRIPTION
The warning should not be issued in cases where the user didn't request any parallelism.