### PR TITLE
Make `records_pattern` the first parameter of reader functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 - Export members of `sleepecg.io` to main package ([#56](https://github.com/cbrnr/sleepecg/pull/56) by [Florian Hofer](https://github.com/hofaflo))
+- Reader functions now have `records_pattern` as their first parameter and `data_dir` is the last one ([#65](https://github.com/cbrnr/sleepecg/pull/65) by [Florian Hofer](https://github.com/hofaflo))
 
 ## [0.3.0] - 2021-08-25
 ### Added

--- a/examples/benchmark/benchmark_detectors.py
+++ b/examples/benchmark/benchmark_detectors.py
@@ -41,7 +41,7 @@ csv_filepath = outfile_dir / f'{benchmark}__{db_slug}__{timestamp}.csv'
 print(f'Storing results to {csv_filepath.resolve()}')
 
 data_dir = Path(cfg.get('data_dir', '~/.sleepecg/datasets')).expanduser()
-records = list(reader_dispatch(data_dir, db_slug))
+records = list(reader_dispatch(db_slug, data_dir))
 print(f'Loaded {len(records)} records from {db_slug}.')
 
 

--- a/examples/benchmark/utils.py
+++ b/examples/benchmark/utils.py
@@ -20,16 +20,16 @@ import sleepecg
 from sleepecg.io.ecg_readers import ECGRecord
 
 
-def reader_dispatch(data_dir: str, db_slug: str) -> Iterator[ECGRecord]:
+def reader_dispatch(db_slug: str, data_dir: str) -> Iterator[ECGRecord]:
     """
     Read ECG records from mitdb, ltdb or gudb.
 
     Parameters
     ----------
-    data_dir : str
-        Directory where all datasets are stored.
     db_slug : str
         Short identifier of a dataset, e.g. `'mitdb'`.
+    data_dir : str
+        Directory where all datasets are stored.
 
     Yields
     ------

--- a/sleepecg/io/ecg_readers.py
+++ b/sleepecg/io/ecg_readers.py
@@ -44,23 +44,23 @@ class ECGRecord:
 
 
 def read_ltdb(
-    data_dir: Optional[Union[str, Path]] = None,
     records_pattern: str = '*',
     offline: bool = False,
+    data_dir: Optional[Union[str, Path]] = None,
 ) -> Iterator[ECGRecord]:
     """
     Lazily read records from LTDB (https://physionet.org/content/ltdb/).
 
     Parameters
     ----------
-    data_dir : str | pathlib.Path, optional
-        Directory where all datasets are stored. If `None` (default), the
-        value will be taken from the configuration.
     records_pattern : str, optional
         Glob-like pattern to select record IDs, by default `'*'`.
     offline : bool, optional
         If `True`, only local files will be used (i.e. no files will be
         downloaded), by default `False`.
+    data_dir : str | pathlib.Path, optional
+        Directory where all datasets are stored. If `None` (default), the
+        value will be taken from the configuration.
 
     Yields
     ------
@@ -71,27 +71,27 @@ def read_ltdb(
     """
     if data_dir is None:
         data_dir = get_config('data_dir')
-    yield from _read_mitbih(data_dir, 'ltdb', records_pattern, offline)
+    yield from _read_mitbih('ltdb', records_pattern, offline, data_dir)
 
 
 def read_mitdb(
-    data_dir: Optional[Union[str, Path]] = None,
     records_pattern: str = '*',
     offline: bool = False,
+    data_dir: Optional[Union[str, Path]] = None,
 ) -> Iterator[ECGRecord]:
     """
     Lazily read records from MITDB (https://physionet.org/content/mitdb/).
 
     Parameters
     ----------
-    data_dir : str | pathlib.Path, optional
-        Directory where all datasets are stored. If `None` (default), the
-        value will be taken from the configuration.
     records_pattern : str, optional
         Glob-like pattern to select record IDs, by default `'*'`.
     offline : bool, optional
         If `True`, only local files will be used (i.e. no files will be
         downloaded), by default `False`.
+    data_dir : str | pathlib.Path, optional
+        Directory where all datasets are stored. If `None` (default), the
+        value will be taken from the configuration.
 
     Yields
     ------
@@ -102,14 +102,14 @@ def read_mitdb(
     """
     if data_dir is None:
         data_dir = get_config('data_dir')
-    yield from _read_mitbih(data_dir, 'mitdb', records_pattern, offline)
+    yield from _read_mitbih('mitdb', records_pattern, offline, data_dir)
 
 
 def _read_mitbih(
-    data_dir: Union[str, Path],
     db_slug: str,
-    records_pattern: str = '*',
-    offline: bool = False,
+    records_pattern: str,
+    offline: bool,
+    data_dir: Union[str, Path],
 ) -> Iterator[ECGRecord]:
     """
     Lazily reads records from MIT-BIH datasets (e.g. MITDB, LTDB).
@@ -118,15 +118,15 @@ def _read_mitbih(
 
     Parameters
     ----------
-    data_dir : str | pathlib.Path
-        Directory where all datasets are stored.
     db_slug : str
         Short identifier of a database, e.g. `'mitdb'`.
-    records_pattern : str, optional
-        Glob-like pattern to select record IDs, by default `'*'`.
-    offline : bool, optional
+    records_pattern : str
+        Glob-like pattern to select record IDs.
+    offline : bool
         If `True`, only local files will be used (i.e. no files will be
-        downloaded), by default `False`.
+        downloaded).
+    data_dir : str | pathlib.Path
+        Directory where all datasets are stored.
 
     Yields
     ------
@@ -174,8 +174,8 @@ def _read_mitbih(
 
 
 def read_gudb(
-    data_dir: Optional[Union[str, Path]] = None,
     offline: bool = False,
+    data_dir: Optional[Union[str, Path]] = None,
 ) -> Iterator[ECGRecord]:
     """
     Lazily reads records from GUDB (https://berndporr.github.io/ECG-GUDB/).
@@ -184,12 +184,12 @@ def read_gudb(
 
     Parameters
     ----------
-    data_dir : str | pathlib.Path, optional
-        Directory where all datasets are stored. If `None` (default), the
-        value will be taken from the configuration.
     offline : bool, optional
         If `True`, only local files will be used (i.e. no files will be
         downloaded), by default `False`.
+    data_dir : str | pathlib.Path, optional
+        Directory where all datasets are stored. If `None` (default), the
+        value will be taken from the configuration.
 
     Yields
     ------

--- a/sleepecg/io/sleep_readers.py
+++ b/sleepecg/io/sleep_readers.py
@@ -161,11 +161,11 @@ def _parse_nsrr_xml(xml_filepath: Path) -> _ParseNsrrXmlResult:
 
 
 def read_mesa(
-    data_dir: Optional[Union[str, Path]] = None,
     records_pattern: str = '*',
     heartbeats_source: str = 'annotation',
     offline: bool = False,
     keep_edfs: bool = False,
+    data_dir: Optional[Union[str, Path]] = None,
 ) -> Iterator[SleepRecord]:
     """
     Lazily read records from MESA (https://sleepdata.org/datasets/mesa).
@@ -179,9 +179,6 @@ def read_mesa(
 
     Parameters
     ----------
-    data_dir : str | pathlib.Path, optional
-        Directory where all datasets are stored. If `None` (default), the
-        value will be taken from the configuration.
     records_pattern : str, optional
          Glob-like pattern to select record IDs, by default `'*'`.
     heartbeats_source : {'annotation', 'cached', 'ecg'}, optional
@@ -198,6 +195,9 @@ def read_mesa(
     keep_edfs : bool, optional
         If `False`, remove `.edf` after heartbeat detection, by default
         `False`.
+    data_dir : str | pathlib.Path, optional
+        Directory where all datasets are stored. If `None` (default), the
+        value will be taken from the configuration.
 
     Yields
     ------
@@ -365,9 +365,9 @@ def read_mesa(
 
 
 def read_slpdb(
-    data_dir: Optional[Union[str, Path]] = None,
     records_pattern: str = '*',
     offline: bool = False,
+    data_dir: Optional[Union[str, Path]] = None,
 ) -> Iterator[SleepRecord]:
     """
     Lazily read records from SLPDB (https://physionet.org/content/slpdb).
@@ -376,14 +376,14 @@ def read_slpdb(
 
     Parameters
     ----------
-    data_dir : str | pathlib.Path, optional
-        Directory where all datasets are stored. If `None` (default), the
-        value will be taken from the configuration.
     records_pattern : str, optional
          Glob-like pattern to select record IDs, by default `'*'`.
     offline : bool, optional
         If `True`, search for local files only instead of downloading from
         PhysioNet, by default `False`.
+    data_dir : str | pathlib.Path, optional
+        Directory where all datasets are stored. If `None` (default), the
+        value will be taken from the configuration.
 
     Yields
     ------
@@ -465,11 +465,11 @@ def read_slpdb(
 
 
 def read_shhs(
-    data_dir: Optional[Union[str, Path]] = None,
     records_pattern: str = '*',
     use_cached_heartbeats: bool = True,
     offline: bool = False,
     keep_edfs: bool = False,
+    data_dir: Optional[Union[str, Path]] = None,
 ) -> Iterator[SleepRecord]:
     """
     Lazily read records from SHHS (https://sleepdata.org/datasets/shhs).
@@ -483,9 +483,6 @@ def read_shhs(
 
     Parameters
     ----------
-    data_dir : str | pathlib.Path, optional
-        Directory where all datasets are stored. If `None` (default), the
-        value will be taken from the configuration.
     records_pattern : str, optional
          Glob-like pattern to select record IDs, by default `'*'`.
     use_cached_heartbeats : bool, optional
@@ -498,6 +495,9 @@ def read_shhs(
     keep_edfs : bool, optional
         If `False`, remove `.edf` after heartbeat detection, by default
         `False`.
+    data_dir : str | pathlib.Path, optional
+        Directory where all datasets are stored. If `None` (default), the
+        value will be taken from the configuration.
 
     Yields
     ------


### PR DESCRIPTION
In most cases, users will not want to pass `data_dir`, as it takes the value from the config file by default. Moving it to the end of the parameter list would allow to pass the record selection without a keyword, so instead of writing this:
```python
mesa = read_mesa(records_pattern='0001')
```
you could write this:
```python
mesa = read_mesa('0001')
```
