### PR TITLE
Fix `reader_dispatch` not yielding anything

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [UNRELEASED]
+### Fixed
+- Fix `reader_dispatch` in `examples/benchmark/utils.py` not yielding anything  ([#68](https://github.com/cbrnr/sleepecg/pull/68) by [Florian Hofer](https://github.com/hofaflo))
 
 ## [0.4.0] - 2022-01-11
 ### Added

--- a/examples/benchmark/utils.py
+++ b/examples/benchmark/utils.py
@@ -45,7 +45,7 @@ def reader_dispatch(db_slug: str, data_dir: str) -> Iterator[ECGRecord]:
     }
     if db_slug not in readers:
         raise ValueError(f'Invalid db_slug: {db_slug}')
-    yield from readers[db_slug](data_dir)
+    yield from readers[db_slug](data_dir=data_dir)
 
 
 def detector_dispatch(ecg: np.ndarray, fs: float, detector: str) -> np.ndarray:


### PR DESCRIPTION
`data_dir` has to be passed as a keyword argument since #65 changed the order of arguments in the reader functions

fixes #67 