### PR TITLE
Add option to export records in benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Added
 - Add metadata feature extraction ([#70](https://github.com/cbrnr/sleepecg/pull/70) by [Florian Hofer](https://github.com/hofaflo))
 - Add ability to read annotated heartbeats and subject data from SHHS ([#72](https://github.com/cbrnr/sleepecg/pull/72) by [Florian Hofer](https://github.com/hofaflo))
+- Add option to export benchmark records to text files ([#71](https://github.com/cbrnr/sleepecg/pull/71) by [Clemens Brunner](https://github.com/cbrnr))
 
 ## [0.4.1] - 2022-01-14
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ### Added
 - Add metadata feature extraction ([#70](https://github.com/cbrnr/sleepecg/pull/70) by [Florian Hofer](https://github.com/hofaflo))
 - Add ability to read annotated heartbeats and subject data from SHHS ([#72](https://github.com/cbrnr/sleepecg/pull/72) by [Florian Hofer](https://github.com/hofaflo))
-- Add function `export_record` to export ECG records to text files ([#71](https://github.com/cbrnr/sleepecg/pull/71) by [Clemens Brunner](https://github.com/cbrnr))
+- Add function `export_ecg_record` to export ECG records to text files ([#71](https://github.com/cbrnr/sleepecg/pull/71) by [Clemens Brunner](https://github.com/cbrnr))
 
 ## [0.4.1] - 2022-01-14
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ### Added
 - Add metadata feature extraction ([#70](https://github.com/cbrnr/sleepecg/pull/70) by [Florian Hofer](https://github.com/hofaflo))
 - Add ability to read annotated heartbeats and subject data from SHHS ([#72](https://github.com/cbrnr/sleepecg/pull/72) by [Florian Hofer](https://github.com/hofaflo))
-- Add option to export benchmark records to text files ([#71](https://github.com/cbrnr/sleepecg/pull/71) by [Clemens Brunner](https://github.com/cbrnr))
+- Add function `export_record` to export ECG records to text files ([#71](https://github.com/cbrnr/sleepecg/pull/71) by [Clemens Brunner](https://github.com/cbrnr))
 
 ## [0.4.1] - 2022-01-14
 ### Fixed

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -15,6 +15,7 @@ See :ref:`Datasets <datasets>` for information about the available datasets and 
 
    download_nsrr
    download_physionet
+   export_ecg_record
    read_gudb
    read_ltdb
    read_mesa

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -27,6 +27,7 @@ A benchmark configuration is specified below a unique top-level key in `config.y
 |`data_dir`|`str`|`'~/.sleepecg/datasets'`|Path where all datasets are stored. Required files will be downloaded if they don't exist.|
 |`outfile_dir`|`str`|`'.'`|Path where the evaluation results should be stored.|
 |`db_slug`|`str`||Which dataset to use for evaluation. Possible values: [`mitdb`](https://physionet.org/content/mitdb/1.0.0/), [`ltdb`](https://physionet.org/content/ltdb/1.0.0/), [`gudb`](https://github.com/berndporr/ECG-GUDB).|
+|`export_records`|`bool`|`False`|Whether to export all records used in the benchmark as text files.|
 |`detectors`|`list[str]`||Detectors to be evaluated. For possible options, see [`utils.detector_dispatch`](https://github.com/cbrnr/sleepecg/blob/main/examples/benchmark/utils.py#L51-L94).|
 |`signal_lengths`|`list[int]`||Length in minutes to which each ECG signal should be sliced. If a signal is too short, it is skipped.|
 |`max_distance`|`float`|`0.1`|Maximum temporal distance in seconds between detected and annotated beats to count as a successful detection.|

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -2,16 +2,16 @@
 This example reproduces the benchmarks shown in the [docs](https://sleepecg.readthedocs.io/en/latest/heartbeat_detection.html).
 
 ## Usage
-To run the benchmark, create a virtual enviroment and install the requirements using
+To run the benchmark, create a virtual enviroment and install the requirements with:
 ```
 pip install -r requirements-benchmark.txt
 ```
 
-and execute
+Then execute
 ```
-python benchmark_detectors.py <benchmark>
+python benchmark_detectors.py [<benchmark>]
 ```
-where `<benchmark>` is a top-level key in `config.yml` (see section [Configuration](#configuration)). Possible values are `runtime`, `metrics`, and `rri_similarity`.
+where the optional `[<benchmark>]` argument is a top-level key in `config.yml` (see section [Configuration](#configuration)). Possible values are `runtime`, `metrics`, and `rri_similarity`. If not provided, the `runtime` benchmark is executed.
 
 Plots can be created by executing
 ```
@@ -27,7 +27,7 @@ A benchmark configuration is specified below a unique top-level key in `config.y
 |`data_dir`|`str`|`'~/.sleepecg/datasets'`|Path where all datasets are stored. Required files will be downloaded if they don't exist.|
 |`outfile_dir`|`str`|`'.'`|Path where the evaluation results should be stored.|
 |`db_slug`|`str`||Which dataset to use for evaluation. Possible values: [`mitdb`](https://physionet.org/content/mitdb/1.0.0/), [`ltdb`](https://physionet.org/content/ltdb/1.0.0/), [`gudb`](https://github.com/berndporr/ECG-GUDB).|
-|`export_records`|`bool`|`False`|Whether to export all records used in the benchmark as text files.|
+|`export_records`|`bool`|`False`|Whether to export all records from a benchmark as text files (in `outfile_dir`).|
 |`detectors`|`list[str]`||Detectors to be evaluated. For possible options, see [`utils.detector_dispatch`](https://github.com/cbrnr/sleepecg/blob/main/examples/benchmark/utils.py#L51-L94).|
 |`signal_lengths`|`list[int]`||Length in minutes to which each ECG signal should be sliced. If a signal is too short, it is skipped.|
 |`max_distance`|`float`|`0.1`|Maximum temporal distance in seconds between detected and annotated beats to count as a successful detection.|

--- a/examples/benchmark/benchmark_detectors.py
+++ b/examples/benchmark/benchmark_detectors.py
@@ -49,13 +49,10 @@ records = list(reader_dispatch(db_slug, data_dir))
 print(f'Loaded {len(records)} records from {db_slug}.')
 
 if cfg.get('export_records', False):
+    from sleepecg import export_record
     print(f'Exporting records to {outfile_dir.resolve()}.')
     for record in records:
-        np.savetxt(
-            outfile_dir / f'{record.id}-{record.lead}.txt',
-            np.atleast_2d(record.ecg),
-            fmt='%.3f',
-        )
+        export_record(record, outfile_dir / f'{record.id}-{record.lead}.txt')
 
 fieldnames = [
     'record_id', 'lead', 'fs', 'num_samples', 'detector', 'max_distance', 'runtime', 'TP',

--- a/examples/benchmark/benchmark_detectors.py
+++ b/examples/benchmark/benchmark_detectors.py
@@ -49,10 +49,10 @@ records = list(reader_dispatch(db_slug, data_dir))
 print(f'Loaded {len(records)} records from {db_slug}.')
 
 if cfg.get('export_records', False):
-    from sleepecg import export_record
+    from sleepecg import export_ecg_record
     print(f'Exporting records to {outfile_dir.resolve()}.')
     for record in records:
-        export_record(record, outfile_dir / f'{record.id}-{record.lead}.txt')
+        export_ecg_record(record, outfile_dir / f'{record.id}-{record.lead}.txt')
 
 fieldnames = [
     'record_id', 'lead', 'fs', 'num_samples', 'detector', 'max_distance', 'runtime', 'TP',

--- a/examples/benchmark/benchmark_detectors.py
+++ b/examples/benchmark/benchmark_detectors.py
@@ -16,7 +16,7 @@ from tqdm import tqdm
 from utils import detector_dispatch, evaluate_single, reader_dispatch
 
 if len(sys.argv) == 1:
-    print("No benchmark specified, executing 'runtime' benchmark.")
+    print('No benchmark specified, executing "runtime" benchmark.')
     benchmark = 'runtime'
 elif len(sys.argv) > 2:
     print('Usage: python benchmark_detectors.py [<benchmark>]')
@@ -53,7 +53,7 @@ if cfg.get('export_records', False):
         np.savetxt(
             outfile_dir / f"{record.id}-{record.lead}.txt",
             np.atleast_2d(record.ecg),
-            fmt="%.3f"
+            fmt="%.3f",
         )
 
 fieldnames = [

--- a/examples/benchmark/benchmark_detectors.py
+++ b/examples/benchmark/benchmark_detectors.py
@@ -42,13 +42,14 @@ outfile_dir.mkdir(parents=True, exist_ok=True)
 db_slug = cfg['db_slug']
 timestamp = time.strftime('%Y_%m_%d__%H_%M_%S')
 csv_filepath = outfile_dir / f'{benchmark}__{db_slug}__{timestamp}.csv'
-print(f'Storing results to {csv_filepath.resolve()}')
+print(f'Storing results to {csv_filepath.resolve()}.')
 
 data_dir = Path(cfg.get('data_dir', '~/.sleepecg/datasets')).expanduser()
 records = list(reader_dispatch(db_slug, data_dir))
 print(f'Loaded {len(records)} records from {db_slug}.')
 
 if cfg.get('export_records', False):
+    print(f'Exporting records to {outfile_dir.resolve()}.')
     for record in records:
         np.savetxt(
             outfile_dir / f'{record.id}-{record.lead}.txt',

--- a/examples/benchmark/benchmark_detectors.py
+++ b/examples/benchmark/benchmark_detectors.py
@@ -51,9 +51,9 @@ print(f'Loaded {len(records)} records from {db_slug}.')
 if cfg.get('export_records', False):
     for record in records:
         np.savetxt(
-            outfile_dir / f"{record.id}-{record.lead}.txt",
+            outfile_dir / f'{record.id}-{record.lead}.txt',
             np.atleast_2d(record.ecg),
-            fmt="%.3f",
+            fmt='%.3f',
         )
 
 fieldnames = [

--- a/sleepecg/io/__init__.py
+++ b/sleepecg/io/__init__.py
@@ -1,6 +1,6 @@
 """Functions for downloading and reading datasets."""
 
-from .ecg_readers import ECGRecord, export_record, read_gudb, read_ltdb, read_mitdb
+from .ecg_readers import ECGRecord, export_ecg_record, read_gudb, read_ltdb, read_mitdb
 from .nsrr import download_nsrr, set_nsrr_token
 from .physionet import download_physionet
 from .sleep_readers import SleepRecord, SleepStage, read_mesa, read_shhs, read_slpdb

--- a/sleepecg/io/__init__.py
+++ b/sleepecg/io/__init__.py
@@ -1,6 +1,6 @@
 """Functions for downloading and reading datasets."""
 
-from .ecg_readers import ECGRecord, read_gudb, read_ltdb, read_mitdb
+from .ecg_readers import ECGRecord, export_record, read_gudb, read_ltdb, read_mitdb
 from .nsrr import download_nsrr, set_nsrr_token
 from .physionet import download_physionet
 from .sleep_readers import SleepRecord, SleepStage, read_mesa, read_shhs, read_slpdb

--- a/sleepecg/io/ecg_readers.py
+++ b/sleepecg/io/ecg_readers.py
@@ -17,32 +17,6 @@ from .physionet import _list_physionet, download_physionet
 from .utils import _download_file
 
 
-def export_record(record: 'ECGRecord', filename: Union[str, Path]) -> None:
-    """
-    Export record to a CSV file.
-
-    Parameters
-    ----------
-    record : ECGRecord
-        ECG record to export.
-    filename : str | pathlib.Path
-        File name to write to.
-    """
-    if Path(filename).suffix.lower() != '.csv':
-        filename = filename + '.csv'
-
-    rpeaks = np.zeros_like(record.ecg, dtype=int)
-    rpeaks[record.annotation] = 1
-
-    np.savetxt(
-        filename,
-        np.vstack((record.ecg, rpeaks)).T,
-        fmt='%.3f,%d',
-        header=f'# fs: {record.fs}Hz\necg,rpeak',
-        comments='',
-    )
-
-
 @dataclass
 class ECGRecord:
     """
@@ -67,6 +41,32 @@ class ECGRecord:
     annotation: np.ndarray
     lead: Optional[str] = None
     id: Optional[str] = None
+
+
+def export_record(record: ECGRecord, filename: Union[str, Path]) -> None:
+    """
+    Export record to a CSV file.
+
+    Parameters
+    ----------
+    record : ECGRecord
+        ECG record to export.
+    filename : str | pathlib.Path
+        File name to write to.
+    """
+    if Path(filename).suffix.lower() != '.csv':
+        filename = filename + '.csv'
+
+    rpeaks = np.zeros_like(record.ecg, dtype=int)
+    rpeaks[record.annotation] = 1
+
+    np.savetxt(
+        filename,
+        np.vstack((record.ecg, rpeaks)).T,
+        fmt='%.3f,%d',
+        header=f'# fs: {record.fs}Hz\necg,rpeak',
+        comments='',
+    )
 
 
 def read_ltdb(

--- a/sleepecg/io/ecg_readers.py
+++ b/sleepecg/io/ecg_readers.py
@@ -43,7 +43,7 @@ class ECGRecord:
     id: Optional[str] = None
 
 
-def export_record(record: ECGRecord, filename: Union[str, Path]) -> None:
+def export_ecg_record(record: ECGRecord, filename: Union[str, Path]) -> None:
     """
     Export record to a CSV file.
 
@@ -54,7 +54,7 @@ def export_record(record: ECGRecord, filename: Union[str, Path]) -> None:
     filename : str | pathlib.Path
         File name to write to.
     """
-    if Path(filename).suffix.lower() != '.csv':
+    if not Path(filename).suffix:
         filename = filename + '.csv'
 
     rpeaks = np.zeros_like(record.ecg, dtype=int)

--- a/sleepecg/io/ecg_readers.py
+++ b/sleepecg/io/ecg_readers.py
@@ -17,6 +17,32 @@ from .physionet import _list_physionet, download_physionet
 from .utils import _download_file
 
 
+def export_record(record: 'ECGRecord', filename: Union[str, Path]) -> None:
+    """
+    Export record to a CSV file.
+
+    Parameters
+    ----------
+    record : ECGRecord
+        ECG record to export.
+    filename : str | pathlib.Path
+        File name to write to.
+    """
+    if Path(filename).suffix.lower() != '.csv':
+        filename = filename + '.csv'
+
+    rpeaks = np.zeros_like(record.ecg, dtype=int)
+    rpeaks[record.annotation] = 1
+
+    np.savetxt(
+        filename,
+        np.vstack((record.ecg, rpeaks)).T,
+        fmt='%.3f,%d',
+        header=f'# fs: {record.fs}Hz\necg,rpeak',
+        comments='',
+    )
+
+
 @dataclass
 class ECGRecord:
     """


### PR DESCRIPTION
By default, the config option `export_records` is `False` so records only exported if explicitly requested.