### PR TITLE
Restructure and clarify extras_require

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,8 @@ inside your local clone. After that, the checks required in the CI job will be r
 
 
 ## Tests
-SleepECG uses [`pytest`](https://docs.pytest.org/) for unit tests. The structure of `sleepecg/tests/` follows that of the package itself, e.g. the test module for `sleepecg.io.nsrr` would be `sleepecg/tests/io/test_nsrr.py`.
+SleepECG uses [`pytest`](https://docs.pytest.org/) for unit tests. The structure of `sleepecg/tests/` follows that of the package itself, e.g. the test module for `sleepecg.io.nsrr` would be `sleepecg/tests/io/test_nsrr.py`. If a new test requires a package that is not part of the core dependencies (i.e. listed under `install_requires` in `setup.cfg`), make sure to add it to the optional requirement categories `dev` and `cibw`.
+
 To run the tests, execute
 ```
 pytest

--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ Alternatively, install via [conda](https://docs.conda.io/en/latest/):
 conda install -c conda-forge sleepecg
 ```
 
+Optional dependencies provide additional features if installed:
+- joblib≥1.0.0 (parallelized feature extraction)
+- mne≥0.23.0 (read data from [MESA](https://sleepdata.org/datasets/mesa), [SHHS](https://sleepdata.org/datasets/shhs))
+- numba≥0.53.0 (JIT-compiled heartbeat detector)
+- pandas≥1.2.0 (read data from [GUDB](https://berndporr.github.io/ECG-GUDB))
+- wfdb≥3.3.0 (read data from [SLPDB](https://physionet.org/content/slpdb), [MITDB](https://physionet.org/content/mitdb), [LTDB](https://physionet.org/content/ltdb))
+
+All optional dependencies can be installed with
+```
+pip install sleepecg[full]
+```
+
 
 ## Contributing
 The [contributing guide](https://github.com/cbrnr/sleepecg/blob/main/CONTRIBUTING.md) contains detailed instructions on how to contribute to SleepECG.

--- a/doc/source/index.md
+++ b/doc/source/index.md
@@ -13,6 +13,7 @@
 # SleepECG
 Welcome! This is the documentation for version **{{ version }}** of SleepECG, a package for sleep stage classification using ECG data.
 
+## Installation
 SleepECG is available on PyPI and can be installed with [pip](https://pip.pypa.io/en/stable/):
 ```
 pip install sleepecg
@@ -22,6 +23,19 @@ Alternatively, install via [conda](https://docs.conda.io/en/latest/):
 conda install -c conda-forge sleepecg
 ```
 
+Optional dependencies provide additional features if installed:
+- joblib≥1.0.0 (parallelized feature extraction)
+- mne≥0.23.0 (read data from [MESA](https://sleepdata.org/datasets/mesa), [SHHS](https://sleepdata.org/datasets/shhs))
+- numba≥0.53.0 (JIT-compiled heartbeat detector)
+- pandas≥1.2.0 (read data from [GUDB](https://berndporr.github.io/ECG-GUDB))
+- wfdb≥3.3.0 (read data from [SLPDB](https://physionet.org/content/slpdb), [MITDB](https://physionet.org/content/mitdb), [LTDB](https://physionet.org/content/ltdb))
+
+All optional dependencies can be installed with
+```
+pip install sleepecg[full]
+```
+
+## Documentation overview
 The [**changelog**](https://github.com/cbrnr/sleepecg/blob/main/CHANGELOG.md) and a [**contributing guide**](https://github.com/cbrnr/sleepecg/blob/main/CONTRIBUTING.md) are available in the [GitHub repo](https://github.com/cbrnr/sleepecg).
 
 [**Datasets**](./datasets) shows all avaiable datasets and instructions about retrieving NSRR data.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ['setuptools', 'wheel', 'oldest-supported-numpy']
 
 [tool.cibuildwheel]
 test-requires = 'pytest'
-test-extras = 'full'
+test-extras = 'cibw'
 test-command = 'pytest {package}'
 skip = 'pp* *musllinux*'
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,7 @@ doc =
 
 # cibuildwheel uses this for running the test suite
 # pytest is installed automatically (see pyproject.toml[tool.cibuildwheel])
-test =
+cibw =
     mne>=0.23.0
     numba>=0.53.0
     pyEDFlib>=0.1.22

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,30 +34,44 @@ install_requires =
 
 
 [options.extras_require]
+# complete package functionality
 full =
     joblib>=1.0.0
     mne>=0.23.0
     numba>=0.53.0
     pandas>=1.2.0
-    pyEDFlib>=0.1.22
     wfdb>=3.3.0
 
+# everything needed for development
 dev =
     furo>=2022.1.2
-    m2r2>=0.3.0
+    joblib>=1.0.0
+    mne>=0.23.0
+    myst-parser>=0.15.0
     numba>=0.53.0
     numpydoc>=1.1.0
+    pandas>=1.2.0
     pre-commit>=2.13.0
+    pyEDFlib>=0.1.22
     pytest>=6.2.0
     setuptools>=56.0.0
     sphinx>=4.1.0
     wfdb>=3.3.0
 
+# Read the Docs uses this when building the documentation
 doc =
     furo
     myst-parser
     numpydoc
     sphinx
+
+# cibuildwheel uses this for running the test suite
+# pytest is installed automatically (see pyproject.toml[tool.cibuildwheel])
+test =
+    mne>=0.23.0
+    numba>=0.53.0
+    pyEDFlib>=0.1.22
+    wfdb>=3.3.0
 
 
 [options.package_data]


### PR DESCRIPTION
Currently the optional dependencies are a bit of a mess:
- `full` should be what's needed for the full functionality of the package, but is actually not documented and just used for the CI tests
- `dev` contains `m2r2` which was made obsolete by switching to `myst-parser` in #36
- `dev` should contain everything needed for development (i.e. the full functionality, test and doc requirements), but doesn't

This fixes all of that and documents the different categories :)