### PR TITLE
Require pyedflib v0.1.25 for tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ dev =
     numpydoc>=1.1.0
     pandas>=1.2.0
     pre-commit>=2.13.0
-    pyEDFlib>=0.1.22
+    pyEDFlib>=0.1.25
     pytest>=6.2.0
     setuptools>=56.0.0
     sphinx>=4.1.0
@@ -70,7 +70,7 @@ doc =
 cibw =
     mne>=0.23.0
     numba>=0.53.0
-    pyEDFlib>=0.1.22
+    pyEDFlib>=0.1.25
     wfdb>=3.3.0
 
 

--- a/sleepecg/test/test_sleep_readers.py
+++ b/sleepecg/test/test_sleep_readers.py
@@ -5,7 +5,6 @@
 """Tests for sleep data reader functions."""
 
 import datetime
-import warnings
 from pathlib import Path
 from typing import List
 
@@ -23,9 +22,7 @@ def _dummy_nsrr_edf(filename: str, hours: float, ecg_channel: str):
     seconds = int(hours * 60 * 60)
     ecg = np.tile(ecg_5_min, int(np.ceil(seconds / 300)))[np.newaxis, :seconds * ECG_FS]
     signal_headers = highlevel.make_signal_headers([ecg_channel], sample_frequency=ECG_FS)
-    with warnings.catch_warnings():
-        warnings.filterwarnings('ignore')
-        highlevel.write_edf(filename, ecg, signal_headers)
+    highlevel.write_edf(filename, ecg, signal_headers)
 
 
 def _dummy_nsrr_xml(filename: str, hours: float, random_state: int):


### PR DESCRIPTION
resolves #40 

The underlying issue was fixed in v0.1.24 but that version required NumPy>=1.22 (see holgern/pyedflib#164), so we should require v0.1.25 instead.
