### PR TITLE
Improvements in preprocess_rri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [UNRELEASED] - YYYY-MM-DD
 ### Added
+- The `preprocess_rri` function no longer operates in-place and instead returns a copy of the input array ([#91](https://github.com/cbrnr/sleepecg/pull/91) by [Raphael Vallat](https://github.com/raphaelvallat))
 - Add more tests and documentation for the Pan-Tompkins detector ([#89](https://github.com/cbrnr/sleepecg/pull/89) by [Raphael Vallat](https://github.com/raphaelvallat))
 
 ## [0.5.0] - 2022-03-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## [UNRELEASED] - YYYY-MM-DD
 ### Added
-- The `preprocess_rri` function no longer operates in-place and instead returns a copy of the input array ([#91](https://github.com/cbrnr/sleepecg/pull/91) by [Raphael Vallat](https://github.com/raphaelvallat))
 - Add more tests and documentation for the Pan-Tompkins detector ([#89](https://github.com/cbrnr/sleepecg/pull/89) by [Raphael Vallat](https://github.com/raphaelvallat))
+
+### Changed
+- The `preprocess_rri` function no longer operates in-place and instead returns a copy of the input array ([#91](https://github.com/cbrnr/sleepecg/pull/91) by [Raphael Vallat](https://github.com/raphaelvallat))
+
 
 ## [0.5.0] - 2022-03-22
 ### Added

--- a/sleepecg/feature_extraction.py
+++ b/sleepecg/feature_extraction.py
@@ -471,13 +471,20 @@ def preprocess_rri(
     -------
     np.ndarray
         The cleaned RRI series.
+
+    Examples
+    --------
+    Mask RR intervals outside the range of 0.4 to 2 seconds (= 30 to 150 bpm)
+
+    >>> from sleepecg import preprocess_rri
+    >>> preprocess_rri([0.5, 0.2, 0.8, 2.5, 0.6], min_rri=0.4, max_rri=2)  # noqa
+    array([0.5, nan, 0.8, nan, 0.6])
     """
-    invalid_rri = np.zeros_like(rri, dtype=bool)
+    rri = np.asarray(rri, dtype=float)
     if min_rri is not None:
-        invalid_rri |= rri < min_rri
+        rri[rri < min_rri] = np.nan
     if max_rri is not None:
-        invalid_rri |= rri > max_rri
-    rri[invalid_rri] = np.nan
+        rri[rri > max_rri] = np.nan
     return rri
 
 

--- a/sleepecg/feature_extraction.py
+++ b/sleepecg/feature_extraction.py
@@ -474,10 +474,11 @@ def preprocess_rri(
 
     Examples
     --------
-    Mask RR intervals outside the range of 0.4 to 2 seconds (= 30 to 150 bpm)
+    Mask RR intervals outside the range of 0.4 to 2 seconds
+    (= 30 to 150 bpm)
 
     >>> from sleepecg import preprocess_rri
-    >>> preprocess_rri([0.5, 0.2, 0.8, 2.5, 0.6], min_rri=0.4, max_rri=2)  # noqa
+    >>> preprocess_rri([0.5, 0.2, 0.8, 2.5, 0.6], min_rri=0.4, max_rri=2)
     array([0.5, nan, 0.8, nan, 0.6])
     """
     rri = np.array(rri, dtype=float)

--- a/sleepecg/feature_extraction.py
+++ b/sleepecg/feature_extraction.py
@@ -480,7 +480,7 @@ def preprocess_rri(
     >>> preprocess_rri([0.5, 0.2, 0.8, 2.5, 0.6], min_rri=0.4, max_rri=2)  # noqa
     array([0.5, nan, 0.8, nan, 0.6])
     """
-    rri = np.asarray(rri, dtype=float)
+    rri = np.array(rri, dtype=float)
     if min_rri is not None:
         rri[rri < min_rri] = np.nan
     if max_rri is not None:

--- a/sleepecg/feature_extraction.py
+++ b/sleepecg/feature_extraction.py
@@ -474,14 +474,13 @@ def preprocess_rri(
 
     Examples
     --------
-    Mask RR intervals outside the range of 0.4 to 2 seconds
-    (= 30 to 150 bpm)
+    Mask RR intervals outside the range of 0.4 to 2 s (= 30 to 150 bpm):
 
     >>> from sleepecg import preprocess_rri
     >>> preprocess_rri([0.5, 0.2, 0.8, 2.5, 0.6], min_rri=0.4, max_rri=2)
     array([0.5, nan, 0.8, nan, 0.6])
     """
-    rri = np.array(rri, dtype=float)
+    rri = np.array(rri, dtype=float)  # make a copy
     if min_rri is not None:
         rri[rri < min_rri] = np.nan
     if max_rri is not None:


### PR DESCRIPTION
- [x] Previously, preprocess_rri was applied in-place, which can be confusing and error-prone. We now return a copy of the array, leaving the original array unchanged.
- [x] Previously, the function would fail if a list was used as the input. We now force the conversion to a numpy.array of dtype float.
- [x] Added an example in docstring

Thanks,
Raphael