### PR TITLE
Handle flat data at the beginning of the recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 ## [0.5.1] - 2022-07-21
 ### Added
 - Add more tests and documentation for the Pan-Tompkins detector ([#89](https://github.com/cbrnr/sleepecg/pull/89) by [Raphael Vallat](https://github.com/raphaelvallat))
-- Better handling of flat data for the Pan-Tompkins detector ([#87](https://github.com/cbrnr/sleepecg/pull/87) by [Raphael Vallat](https://github.com/raphaelvallat))
+- The Pan-Tompkins detector detects flat data at the beginning of a recording to avoid messing up its thresholds ([#87](https://github.com/cbrnr/sleepecg/pull/87) by [Raphael Vallat](https://github.com/raphaelvallat))
 
 ### Changed
 - The `preprocess_rri` function no longer operates in-place and instead returns a copy of the input array ([#91](https://github.com/cbrnr/sleepecg/pull/91) by [Raphael Vallat](https://github.com/raphaelvallat))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 - The detector benchmark example now requires only those packages that are actually used in the benchmark ([#114](https://github.com/cbrnr/sleepecg/pull/114) by [Clemens Brunner](https://github.com/cbrnr))
+- The Pan-Tompkins detector detects flat data at the beginning of a recording to avoid messing up its thresholds ([#87](https://github.com/cbrnr/sleepecg/pull/87) by [Raphael Vallat](https://github.com/raphaelvallat))
 
 ## [0.5.2] - 2022-08-02
 ### Fixed
@@ -12,7 +13,6 @@
 ## [0.5.1] - 2022-07-21
 ### Added
 - Add more tests and documentation for the Pan-Tompkins detector ([#89](https://github.com/cbrnr/sleepecg/pull/89) by [Raphael Vallat](https://github.com/raphaelvallat))
-- The Pan-Tompkins detector detects flat data at the beginning of a recording to avoid messing up its thresholds ([#87](https://github.com/cbrnr/sleepecg/pull/87) by [Raphael Vallat](https://github.com/raphaelvallat))
 
 ### Changed
 - The `preprocess_rri` function no longer operates in-place and instead returns a copy of the input array ([#91](https://github.com/cbrnr/sleepecg/pull/91) by [Raphael Vallat](https://github.com/raphaelvallat))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ## [0.5.1] - 2022-07-21
 ### Added
 - Add more tests and documentation for the Pan-Tompkins detector ([#89](https://github.com/cbrnr/sleepecg/pull/89) by [Raphael Vallat](https://github.com/raphaelvallat))
+- Better handling of flat data for the Pan-Tompkins detector ([#87](https://github.com/cbrnr/sleepecg/pull/87) by [Raphael Vallat](https://github.com/raphaelvallat))
 
 ### Changed
 - The `preprocess_rri` function no longer operates in-place and instead returns a copy of the input array ([#91](https://github.com/cbrnr/sleepecg/pull/91) by [Raphael Vallat](https://github.com/raphaelvallat))

--- a/sleepecg/heartbeats.py
+++ b/sleepecg/heartbeats.py
@@ -105,10 +105,14 @@ def detect_heartbeats(ecg: np.ndarray, fs: float, backend: str = "c") -> np.ndar
     # Check for flat data at the beginning of the recording, which can
     # mess up the detection thresholds.
     # https://github.com/cbrnr/sleepecg/issues/87
-    idx_nonflat = np.nonzero(ecg != ecg[0])[0]
-    if not len(idx_nonflat):
-        raise ValueError('ECG signal is flat. Please check your data.')
-    first_nonflat = idx_nonflat[0]  # First non-flat index
+    assert len(ecg), 'ECG signal has no length.'
+    if ecg[1] == ecg[0]:
+        idx_nonflat = np.nonzero(ecg != ecg[0])[0]
+        if not len(idx_nonflat):
+            raise ValueError('ECG signal is flat. Please check your data.')
+        first_nonflat = idx_nonflat[0]  # First non-flat index
+    else:
+        first_nonflat = 0
 
     # For short signals, creating the bandpass filter makes up a large part
     # of the total runtime. Therefore the filter is cached in a global

--- a/sleepecg/heartbeats.py
+++ b/sleepecg/heartbeats.py
@@ -105,10 +105,10 @@ def detect_heartbeats(ecg: np.ndarray, fs: float, backend: str = "c") -> np.ndar
     # Check for flat data at the beginning of the recording, which can
     # mess up the detection thresholds.
     # https://github.com/cbrnr/sleepecg/issues/87
-    idx_nonflat = np.nonzero(np.diff(ecg))[0]
+    idx_nonflat = np.nonzero(ecg != ecg[0])[0]
     if not len(idx_nonflat):
         raise ValueError(
-            "The ECG signal is flat for the entire recording. Please check your data.")
+            'The ECG signal is flat for the entire recording. Please check your data.')
     first_nonflat = idx_nonflat[0]  # First non-flat index
 
     # For short signals, creating the bandpass filter makes up a large part

--- a/sleepecg/heartbeats.py
+++ b/sleepecg/heartbeats.py
@@ -105,7 +105,7 @@ def detect_heartbeats(ecg: np.ndarray, fs: float, backend: str = "c") -> np.ndar
     # Check for flat data at the beginning of the recording, which can
     # mess up the detection thresholds.
     # https://github.com/cbrnr/sleepecg/issues/87
-    assert len(ecg), 'ECG signal has no length.'
+    assert len(ecg) > 1, 'ECG signal must have more than one sample.'
     if ecg[1] == ecg[0]:
         idx_nonflat = np.nonzero(ecg != ecg[0])[0]
         if not len(idx_nonflat):

--- a/sleepecg/heartbeats.py
+++ b/sleepecg/heartbeats.py
@@ -105,7 +105,8 @@ def detect_heartbeats(ecg: np.ndarray, fs: float, backend: str = "c") -> np.ndar
     # Check for flat data at the beginning of the recording, which can
     # mess up the detection thresholds.
     # https://github.com/cbrnr/sleepecg/issues/87
-    assert len(ecg) > 1, 'ECG signal must have more than one sample.'
+    if len(ecg) < 2:
+        raise ValueError('ECG signal must have more than one sample.')
     if ecg[1] == ecg[0]:
         idx_nonflat = np.nonzero(ecg != ecg[0])[0]
         if not len(idx_nonflat):

--- a/sleepecg/heartbeats.py
+++ b/sleepecg/heartbeats.py
@@ -107,8 +107,7 @@ def detect_heartbeats(ecg: np.ndarray, fs: float, backend: str = "c") -> np.ndar
     # https://github.com/cbrnr/sleepecg/issues/87
     idx_nonflat = np.nonzero(ecg != ecg[0])[0]
     if not len(idx_nonflat):
-        raise ValueError(
-            'The ECG signal is flat for the entire recording. Please check your data.')
+        raise ValueError('ECG signal is flat. Please check your data.')
     first_nonflat = idx_nonflat[0]  # First non-flat index
 
     # For short signals, creating the bandpass filter makes up a large part

--- a/sleepecg/heartbeats.py
+++ b/sleepecg/heartbeats.py
@@ -102,22 +102,18 @@ def detect_heartbeats(ecg: np.ndarray, fs: float, backend: str = "c") -> np.ndar
         warnings.warn(f"Backend {backend!r} not available, using {fallback!r} instead.")
         backend = fallback
 
-    # Check for flat data at the beginning of the recording, which can
-    # mess up the detection thresholds.
-    # https://github.com/cbrnr/sleepecg/issues/87
+    # check for flat data at the beginning to avoid messing up detection thresholds
     if len(ecg) < 2:
-        raise ValueError('ECG signal must have more than one sample.')
+        raise ValueError("ECG signal must have more than one sample.")
     if ecg[1] == ecg[0]:
         idx_nonflat = np.nonzero(ecg != ecg[0])[0]
         if not len(idx_nonflat):
-            raise ValueError('ECG signal is flat. Please check your data.')
-        first_nonflat = idx_nonflat[0]  # First non-flat index
+            raise ValueError("ECG signal is flat. Please check your data.")
+        first_nonflat = idx_nonflat[0]  # first non-flat index
     else:
         first_nonflat = 0
 
-    # For short signals, creating the bandpass filter makes up a large part
-    # of the total runtime. Therefore the filter is cached in a global
-    # variable.
+    # cache filter in global variable to speed up runtime (especially for short signals)
     try:
         sos = _sos_filters[fs]
     except KeyError:

--- a/sleepecg/test/test_feature_extraction.py
+++ b/sleepecg/test/test_feature_extraction.py
@@ -66,12 +66,7 @@ def test_feature_ids():
             [np.nan] * 4,
         ),
         (
-            {
-                "start_time": datetime.time(23, 15, 20),
-                "age": 55,
-                "gender": 1,
-                "weight": 99,
-            },
+            {"start_time": datetime.time(23, 15, 20), "age": 55, "gender": 1, "weight": 99},
             [83720, 55, 1, 99],
         ),
     ],

--- a/sleepecg/test/test_feature_extraction.py
+++ b/sleepecg/test/test_feature_extraction.py
@@ -66,7 +66,12 @@ def test_feature_ids():
             [np.nan] * 4,
         ),
         (
-            {"start_time": datetime.time(23, 15, 20), "age": 55, "gender": 1, "weight": 99},
+            {
+                "start_time": datetime.time(23, 15, 20),
+                "age": 55,
+                "gender": 1,
+                "weight": 99,
+            },
             [83720, 55, 1, 99],
         ),
     ],

--- a/sleepecg/test/test_heartbeat_detection.py
+++ b/sleepecg/test/test_heartbeat_detection.py
@@ -55,17 +55,17 @@ def test_rescaling():
 def test_flat_data():
     """Test the impact of flat data on heartbeat detection."""
     # Flat data at the beginning
-    ecg_pad_before = np.pad(ecg, pad_width=(ecg.size, 0), mode='edge')
-    pks_before = detect_heartbeats(ecg_pad_before, fs)
-    assert f1_score(pks_before - ecg.size, y_true) == 1
+    ecg_pad_beginning = np.pad(ecg, pad_width=(ecg.size, 0), mode="edge")
+    pks_beginning = detect_heartbeats(ecg_pad_beginning, fs)
+    assert f1_score(pks_beginning - ecg.size, y_true) == 1
 
     # Flat data at the end
-    ecg_pad_after = np.pad(ecg, pad_width=(0, ecg.size), mode='edge')
-    pks_after = detect_heartbeats(ecg_pad_after, fs)
-    assert f1_score(pks_after, y_true) == 1
+    ecg_pad_end = np.pad(ecg, pad_width=(0, ecg.size), mode="edge")
+    pks_end = detect_heartbeats(ecg_pad_end, fs)
+    assert f1_score(pks_end, y_true) == 1
 
     # Flat data in the middle
-    ecg_pad_middle = np.hstack((ecg_pad_after, ecg))
+    ecg_pad_middle = np.hstack((ecg_pad_end, ecg))
     pks_middle = detect_heartbeats(ecg_pad_middle, fs)
     assert abs(2 * len(y_true) - len(pks_middle)) < 50
 

--- a/sleepecg/test/test_heartbeat_detection.py
+++ b/sleepecg/test/test_heartbeat_detection.py
@@ -73,6 +73,10 @@ def test_flat_data():
     with pytest.raises(ValueError):
         detect_heartbeats(np.ones(10000), fs)
 
+    # ecg is empty
+    with pytest.raises(ValueError):
+        detect_heartbeats([], fs)
+
 
 def test_squared_moving_integration_args():
     """Test squared moving window integration argument parsing."""

--- a/sleepecg/test/test_heartbeat_detection.py
+++ b/sleepecg/test/test_heartbeat_detection.py
@@ -5,9 +5,8 @@
 """Tests for heartbeat detection."""
 
 import sys
-
-import numpy as np
 import pytest
+import numpy as np
 from scipy.misc import electrocardiogram
 from scipy.signal import resample_poly
 
@@ -16,7 +15,7 @@ from sleepecg import compare_heartbeats, detect_heartbeats
 pytestmark = pytest.mark.c_extension
 ecg = electrocardiogram()
 fs = 360
-y_true = detect_heartbeats(ecg, fs)
+y_true = detect_heartbeats(ecg, fs)  # 478 true peaks
 
 
 def f1_score(y_pred, y_true, max_distance=5):
@@ -50,6 +49,28 @@ def test_rescaling():
         beats = detect_heartbeats(ecg * scale, fs)
         f1 = f1_score(beats, y_true)
         assert f1 == 1, "F1-score after rescaling by {scale} is not 1."
+
+
+def test_flat_data():
+    """Test the impact of flat data on heartbeat detection."""
+    # Flat data at the beginning
+    ecg_pad_before = np.pad(ecg, pad_width=(ecg.size, 0), mode="edge")
+    pks_before = detect_heartbeats(ecg_pad_before, fs)
+    assert f1_score(pks_before - ecg.size, y_true) == 1
+
+    # Flat data at the end
+    ecg_pad_after = np.pad(ecg, pad_width=(0, ecg.size), mode="edge")
+    pks_after = detect_heartbeats(ecg_pad_after, fs)
+    assert f1_score(pks_after, y_true) == 1
+
+    # Flat data in the middle
+    ecg_pad_middle = np.hstack((ecg_pad_after, ecg))
+    pks_middle = detect_heartbeats(ecg_pad_middle, fs)
+    assert abs(2 * len(y_true) - len(pks_middle)) < 50
+
+    # Entire recording is flat
+    with pytest.raises(ValueError):
+        detect_heartbeats(np.ones(10000), fs)
 
 
 def test_squared_moving_integration_args():

--- a/sleepecg/test/test_heartbeat_detection.py
+++ b/sleepecg/test/test_heartbeat_detection.py
@@ -5,8 +5,9 @@
 """Tests for heartbeat detection."""
 
 import sys
-import pytest
+
 import numpy as np
+import pytest
 from scipy.misc import electrocardiogram
 from scipy.signal import resample_poly
 
@@ -54,12 +55,12 @@ def test_rescaling():
 def test_flat_data():
     """Test the impact of flat data on heartbeat detection."""
     # Flat data at the beginning
-    ecg_pad_before = np.pad(ecg, pad_width=(ecg.size, 0), mode="edge")
+    ecg_pad_before = np.pad(ecg, pad_width=(ecg.size, 0), mode='edge')
     pks_before = detect_heartbeats(ecg_pad_before, fs)
     assert f1_score(pks_before - ecg.size, y_true) == 1
 
     # Flat data at the end
-    ecg_pad_after = np.pad(ecg, pad_width=(0, ecg.size), mode="edge")
+    ecg_pad_after = np.pad(ecg, pad_width=(0, ecg.size), mode='edge')
     pks_after = detect_heartbeats(ecg_pad_after, fs)
     assert f1_score(pks_after, y_true) == 1
 


### PR DESCRIPTION
Fixes https://github.com/cbrnr/sleepecg/issues/87

Flat data at the beginning of the ECG recording can mess up the Pan & Tompkins heartbeat detection. This PR adds a fix for that, such that the heartbeat detection only starts after the first non-flat sample of the data. The index of the first non flat sample is then added back to the array of heartbeat indices.

The overhead of calculating `np.nonzero(np.diff(ecg))[0]` is ~100 ms for a 8 hour ECG signal sampled at 256 Hz, on a 2019 MacBook Pro:

```python
%timeit np.nonzero(np.diff(np.random.rand(256 * 8 * 3600)))
```

I have also added unit tests and updated the changelog.

Feel free to edit,

Thanks,
Raphael