### PR TITLE
Do not print HTTP error for GUDB

### DIFF
--- a/sleepecg/io/ecg_readers.py
+++ b/sleepecg/io/ecg_readers.py
@@ -247,8 +247,8 @@ def read_gudb(
                     target_filepath = db_dir / experiment_subdir / tsv_filename
                     try:
                         _download_file(ecg_file_url, target_filepath)
-                    except requests.exceptions.HTTPError as error:
-                        print(error)
+                    except requests.exceptions.HTTPError:
+                        pass  # no annotations available
             ecg_data = pd.read_csv(
                 db_dir / experiment_subdir / "ECG.tsv",
                 sep=" ",  # contrary to what .tsv suggests, the data is space-separated


### PR DESCRIPTION
When downloading GUDB, records without annotations printed an HTTPError. This is confusing, because it looks like something went wrong when indeed such records are ignored. Fixes #108.