### PR TITLE
Trigger imports at heartbeat detector benchmark start

### DIFF
--- a/examples/benchmark/benchmark_detectors.py
+++ b/examples/benchmark/benchmark_detectors.py
@@ -70,9 +70,9 @@ fieldnames = [
 if cfg.get("calc_rri_similarity", False):
     fieldnames += ["pearsonr", "spearmanr", "rmse"]
 
-# Trigger jit compilation to make runtime benchmarks representative
-if "sleepecg-numba" in cfg["detectors"]:
-    detector_dispatch(records[0].ecg[: 10 * records[0].fs], records[0].fs, "sleepecg-numba")
+# Trigger imports and jit compilation to make runtime benchmarks representative
+for detector in cfg["detectors"]:
+    detector_dispatch(records[0].ecg[: 10 * records[0].fs], records[0].fs, detector)
 
 
 with open(csv_filepath, "w", newline="") as csv_file:


### PR DESCRIPTION
Since #114. the detector packages are imported inside `detector_dispatch`, making the first call to the function take longer than subsequent ones. To keep runtimes similar, each detector should run once before the actual benchmark, triggering the required imports.