### PR TITLE
Remove zero-crossing check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - The detector benchmark example now requires only those packages that are actually used in the benchmark ([#114](https://github.com/cbrnr/sleepecg/pull/114) by [Clemens Brunner](https://github.com/cbrnr))
 - The Pan-Tompkins detector detects flat data at the beginning of a recording to avoid messing up its thresholds ([#87](https://github.com/cbrnr/sleepecg/pull/87) by [Raphael Vallat](https://github.com/raphaelvallat))
 - Switch documentation from Sphinx to MkDocs ([#119](https://github.com/cbrnr/sleepecg/pull/119) by [Clemens Brunner](https://github.com/cbrnr))
+- Remove unnecessary detection of first zero-crossing in Pan-Tompkins detector ([#120](https://github.com/cbrnr/sleepecg/pull/120) by [Clemens Brunner](https://github.com/cbrnr))
 
 ## [0.5.2] - 2022-08-02
 ### Fixed

--- a/sleepecg/heartbeats.py
+++ b/sleepecg/heartbeats.py
@@ -130,11 +130,6 @@ def detect_heartbeats(ecg: np.ndarray, fs: float, backend: str = "c") -> np.ndar
     # filtering the signal at the first non-flat index.
     filtered_ecg = scipy.signal.sosfiltfilt(sos, ecg[first_nonflat:])
 
-    # Set everything until the first zero-crossing to zero. For efficiency, only the first 2
-    # seconds are checked.
-    signal_start = np.where(np.diff(np.signbit(filtered_ecg[: int(2 * fs)])))[0][0] + 1
-    filtered_ecg[:signal_start] = 0
-
     # scipy.signal.sosfiltfilt returns an array with negative strides. Both `np.correlate`
     # and `_thresholding` require contiguity, so ensuring this here once reduces total
     # runtime.


### PR DESCRIPTION
It could be that setting all values to zero before the first zero-crossing is not necessary (anymore). I'm currently running our benchmarks to see if it had any influence.