### PR TITLE
Fix bug where setting user config values lets get_config retrieve the wrong key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - The Pan-Tompkins detector detects flat data at the beginning of a recording to avoid messing up its thresholds ([#87](https://github.com/cbrnr/sleepecg/pull/87) by [Raphael Vallat](https://github.com/raphaelvallat))
 - Switch documentation from Sphinx to MkDocs ([#119](https://github.com/cbrnr/sleepecg/pull/119) by [Clemens Brunner](https://github.com/cbrnr))
 
+### Fixed
+- Fix bug where setting user config values lets `get_config`retrieve the wrong key ([#123](https://github.com/cbrnr/sleepecg/pull/123) by [Florian Hofer](https://github.com/hofaflo))
+
 ## [0.5.2] - 2022-08-02
 ### Fixed
 - Include classifiers and tests ([#104](https://github.com/cbrnr/sleepecg/pull/104) by [Clemens Brunner](https://github.com/cbrnr))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Switch documentation from Sphinx to MkDocs ([#119](https://github.com/cbrnr/sleepecg/pull/119) by [Clemens Brunner](https://github.com/cbrnr))
 
 ### Fixed
-- Fix bug where setting user config values lets `get_config`retrieve the wrong key ([#123](https://github.com/cbrnr/sleepecg/pull/123) by [Florian Hofer](https://github.com/hofaflo))
+- Fix bug where setting user config values lets `get_config` retrieve the wrong key ([#123](https://github.com/cbrnr/sleepecg/pull/123) by [Florian Hofer](https://github.com/hofaflo))
 
 ## [0.5.2] - 2022-08-02
 ### Fixed

--- a/sleepecg/config.py
+++ b/sleepecg/config.py
@@ -49,11 +49,10 @@ def get_config(key: Optional[str] = None) -> Any:
     """
     config = _read_yaml(_DEFAULT_CONFIG_PATH)
     user_config = _read_yaml(_USER_CONFIG_PATH)
-    for key in user_config:
-        if key not in config:
-            raise ValueError(
-                f"Invalid key found in user config at {_USER_CONFIG_PATH}: {key}"
-            )
+    if invalid_keys := set(user_config) - set(config):
+        raise ValueError(
+            f"Invalid key(s) found in user config at {_USER_CONFIG_PATH}: {invalid_keys}"
+        )
     config.update(user_config)
 
     if key is None:

--- a/sleepecg/test/test_config.py
+++ b/sleepecg/test/test_config.py
@@ -52,3 +52,12 @@ def test_get_all_config():
     """Test trying to get all configuration values as a dict."""
     all_config = get_config()
     assert isinstance(all_config, dict)
+
+
+def test_invalid_key_in_user_config_file():
+    """Test writing an invalid key to the user config file."""
+    with open(sleepecg.config._USER_CONFIG_PATH, "w") as user_config_file:
+        user_config_file.write("invalid_key: 3")
+
+    with pytest.raises(ValueError, match=r"Invalid key\(s\) found .* {'invalid_key'}"):
+        get_config("data_dir")

--- a/sleepecg/test/test_config.py
+++ b/sleepecg/test/test_config.py
@@ -27,10 +27,13 @@ def temp_test_config(tmp_path):
 def test_get_set_del_config():
     """Test setting, getting and deleting a setting."""
     assert get_config("data_dir") == "~/.sleepecg/datasets"
+    assert get_config("classifiers_dir") == "~/.sleepecg/classifiers"
     set_config(data_dir="some_dir")
     assert get_config("data_dir") == "some_dir"
+    assert get_config("classifiers_dir") == "~/.sleepecg/classifiers"
     set_config(data_dir=None)
     assert get_config("data_dir") == "~/.sleepecg/datasets"
+    assert get_config("classifiers_dir") == "~/.sleepecg/classifiers"
 
 
 def test_set_invalid_config():


### PR DESCRIPTION
If a user config file with entries is present, the loop variable `key` overwrites the function argument. Checking all keys at once avoids the name clash.