### PR TITLE
Add Python 3.11 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.8.1
+        uses: pypa/cibuildwheel@v2.11.2
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build wheels and run pytest
-        uses: pypa/cibuildwheel@v2.8.1
+        uses: pypa/cibuildwheel@v2.11.2
 
       - uses: actions/upload-artifact@v3
         with:

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,7 +74,7 @@ doc =
 # pytest is installed automatically (see pyproject.toml[tool.cibuildwheel])
 cibw =
     mne>=1.0.0
-    numba>=0.55.0
+    numba>=0.55.0;python_version<'3.11'
     pyEDFlib>=0.1.25
     wfdb>=3.4.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: CPython
     Typing :: Typed
 license = BSD 3-Clause License

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,9 +40,9 @@ full =
     joblib>=1.0.0
     matplotlib>=3.5.0
     mne>=1.0.0
-    numba>=0.55.0
+    numba>=0.55.0;python_version<'3.11'
     pandas>=1.4.0
-    tensorflow>=2.7.0
+    tensorflow>=2.7.0;python_version<'3.11'
     wfdb>=3.4.0
 
 # everything needed for development
@@ -55,14 +55,14 @@ dev =
     mkdocstrings-python>=0.7.1
     mne>=1.0.0
     mypy>=0.991
-    numba>=0.55.0
+    numba>=0.55.0;python_version<'3.11'
     pandas>=1.4.0
     pre-commit>=2.13.0
     pyEDFlib>=0.1.25
     pytest>=6.2.0
     setuptools>=56.0.0
     sphinx>=4.1.0
-    tensorflow>=2.7.0
+    tensorflow>=2.7.0;python_version<'3.11'
     wfdb>=3.4.0
 
 # Read the Docs uses this when building the documentation

--- a/sleepecg/test/test_heartbeats.py
+++ b/sleepecg/test/test_heartbeats.py
@@ -4,6 +4,8 @@
 
 """Tests for heartbeat detection and detector evaluation."""
 
+import sys
+
 import numpy as np
 import pytest
 
@@ -29,7 +31,19 @@ def mitdb_234_MLII():
     return next(read_mitdb(records_pattern="234"))
 
 
-@pytest.mark.parametrize("backend", ["c", "numba", "python"])
+@pytest.mark.parametrize(
+    "backend",
+    [
+        "c",
+        pytest.param(
+            "numba",
+            marks=pytest.mark.skipif(
+                sys.version_info >= (3, 11), reason="numba does not support Python 3.11 yet"
+            ),
+        ),
+        "python",
+    ],
+)
 def test_detect_heartbeats(mitdb_234_MLII, backend):
     """Test heartbeat detection on mitdb:234:MLII."""
     record = mitdb_234_MLII


### PR DESCRIPTION
I *think* cibuildwheel should already build 3.11 wheels, let's see...