### PR TITLE
Hide TOC in docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,8 @@ theme:
       toggle:
         icon: material/brightness-4
         name: Switch to dark theme
+  hide:
+    - toc
 plugins:
   - mkdocstrings:
       handlers:


### PR DESCRIPTION
This will (hopefully) create more space for the main content.