### PR TITLE
remove dependency on pandas for read_gudb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [UNRELEASED] - YYYY-MM-DD
+### Changed
+- Remove dependency on pandas for `read_gudb` ([#134](https://github.com/cbrnr/sleepecg/pull/134) by [Florian Hofer](https://github.com/hofaflo))
 
 ## [0.5.3] - 2022-12-05
 ### Added

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ Optional dependencies provide additional features:
 - [matplotlib](https://matplotlib.org/) ≥ 3.5.0 (plot ECG time courses, hypnograms, and confusion matrices)
 - [mne](https://mne.tools/stable/index.html) ≥ 1.0.0 (read data from [MESA](https://sleepdata.org/datasets/mesa) and [SHHS](https://sleepdata.org/datasets/shhs))
 - [numba](https://numba.pydata.org/) ≥ 0.55.0 (JIT-compiled heartbeat detector)
-- [pandas](https://pandas.pydata.org/) ≥ 1.4.0 (read data from [GUDB](https://berndporr.github.io/ECG-GUDB))
 - [tensorflow](https://www.tensorflow.org/) ≥ 2.7.0 (sleep stage classification with Keras models)
 - [wfdb](https://github.com/MIT-LCP/wfdb-python/) ≥ 3.4.0 (read data from [SLPDB](https://physionet.org/content/slpdb), [MITDB](https://physionet.org/content/mitdb), and [LTDB](https://physionet.org/content/ltdb))
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,6 @@ Optional dependencies provide additional features:
 - [matplotlib](https://matplotlib.org/) ≥ 3.5.0 (plot ECG time courses, hypnograms, and confusion matrices)
 - [mne](https://mne.tools/stable/index.html) ≥ 1.0.0 (read data from [MESA](https://sleepdata.org/datasets/mesa) and [SHHS](https://sleepdata.org/datasets/shhs))
 - [numba](https://numba.pydata.org/) ≥ 0.55.0 (JIT-compiled heartbeat detector)
-- [pandas](https://pandas.pydata.org/) ≥ 1.4.0 (read data from [GUDB](https://berndporr.github.io/ECG-GUDB))
 - [tensorflow](https://www.tensorflow.org/) ≥ 2.7.0 (sleep stage classification with Keras models)
 - [wfdb](https://github.com/MIT-LCP/wfdb-python/) ≥ 3.4.0 (read data from [SLPDB](https://physionet.org/content/slpdb), [MITDB](https://physionet.org/content/mitdb), and [LTDB](https://physionet.org/content/ltdb))
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,6 @@ full =
     matplotlib>=3.5.0
     mne>=1.0.0
     numba>=0.55.0;python_version<'3.11'
-    pandas>=1.4.0
     tensorflow>=2.7.0;python_version<'3.11'
     wfdb>=3.4.0
 
@@ -56,7 +55,6 @@ dev =
     mne>=1.0.0
     mypy>=0.991
     numba>=0.55.0;python_version<'3.11'
-    pandas>=1.4.0
     pre-commit>=2.13.0
     pyEDFlib>=0.1.25
     pytest>=6.2.0


### PR DESCRIPTION
If I remember correctly, `read_gudb` uses `pandas` because its `load_csv` used to be a lot faster than numpy's `loadtxt`. This changed in numpy 1.23.0 when the function [was implemented in C](https://numpy.org/doc/stable/release/1.23.0-notes.html#faster-np-loadtxt), so I guess we can drop pandas as an optional requirement. I don't think it's necessary to bump the required numpy version to 1.23.0 since it is just a speed improvement, not a functional one, what do you think @cbrnr?