### PR TITLE
Workaround for RTD flyout not working

### DIFF
--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -1,3 +1,7 @@
 .md-grid {
     max-width: 1440px;
 }
+
+.injected {
+    display: none;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,3 +71,4 @@ extra_javascript:
   - javascripts/mathjax.js
   - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
+  - https://code.jquery.com/jquery-3.6.1.min.js

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,4 +71,3 @@ extra_javascript:
   - javascripts/mathjax.js
   - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
-  - https://code.jquery.com/jquery-3.6.1.min.js


### PR DESCRIPTION
Until there is better support for MkDocs on RTD (see https://github.com/readthedocs/readthedocs.org/issues/9720), this workaround disables the flyout.