### PR TITLE
Bump numba

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ full =  # complete package functionality
     joblib>=1.0.0
     matplotlib>=3.5.0
     mne>=1.0.0
-    numba>=0.55.0;python_version<'3.11'
+    numba>=0.55.0
     tensorflow>=2.7.0;python_version<'3.11'
     wfdb>=3.4.0
 
@@ -50,7 +50,7 @@ dev =  # everything needed for development
     mkdocstrings-python>=0.7.1
     mne>=1.0.0
     mypy>=0.991
-    numba>=0.55.0;python_version<'3.11'
+    numba>=0.55.0
     pre-commit>=2.13.0
     pyEDFlib>=0.1.25
     pytest>=6.2.0
@@ -65,7 +65,7 @@ doc =  # RTD uses this when building the documentation
 
 cibw =  # cibuildwheel uses this for running the test suite
     mne>=1.0.0
-    numba>=0.55.0;python_version<'3.11'
+    numba>=0.55.0
     pyEDFlib>=0.1.25
     wfdb>=3.4.0
 


### PR DESCRIPTION
Numba 0.57 with support for Python 3.11 is available.