### PR TITLE
Refine TensorFlow requirement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ full =  # complete package functionality
     numba>=0.55.0
     tensorflow>=2.7.0; sys_platform != 'darwin'
     tensorflow-macos>=2.7.0; sys_platform == 'darwin' and python_version < '3.11'
+    tensorflow-metal>=0.8.0; sys_platform == 'darwin' and python_version < '3.11'
     wfdb>=3.4.0
 
 dev =  # everything needed for development
@@ -59,6 +60,7 @@ dev =  # everything needed for development
     sphinx>=4.1.0
     tensorflow>=2.7.0; sys_platform != 'darwin'
     tensorflow-macos>=2.7.0; sys_platform == 'darwin' and python_version < '3.11'
+    tensorflow-metal>=0.8.0; sys_platform == 'darwin' and python_version < '3.11'
     wfdb>=3.4.0
 
 doc =  # RTD uses this when building the documentation

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,8 @@ full =  # complete package functionality
     matplotlib>=3.5.0
     mne>=1.0.0
     numba>=0.55.0
-    tensorflow>=2.7.0;python_version<'3.11'
+    tensorflow>=2.7.0; sys_platform != 'darwin'
+    tensorflow-macos>=2.7.0; sys_platform == 'darwin' and python_version < '3.11'
     wfdb>=3.4.0
 
 dev =  # everything needed for development
@@ -56,7 +57,8 @@ dev =  # everything needed for development
     pytest>=6.2.0
     setuptools>=56.0.0
     sphinx>=4.1.0
-    tensorflow>=2.7.0;python_version<'3.11'
+    tensorflow>=2.7.0; sys_platform != 'darwin'
+    tensorflow-macos>=2.7.0; sys_platform == 'darwin' and python_version < '3.11'
     wfdb>=3.4.0
 
 doc =  # RTD uses this when building the documentation


### PR DESCRIPTION
TensorFlow works with Python 3.11 on all platforms except macOS. Specifically, there is an optimized `tensorflow-macos` package, which leverages some optimized Apple APIs to make it faster, so we should require that package instead. I still need to test if this really works, I will report back.