### PR TITLE
Remove future imports

### DIFF
--- a/examples/benchmark/utils.py
+++ b/examples/benchmark/utils.py
@@ -4,8 +4,6 @@
 
 """Utilities for runtime and detection quality benchmarks."""
 
-from __future__ import annotations
-
 import time
 from typing import Any, Iterator
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,6 @@ maintainer_email = clemens.brunner@gmail.com
 classifiers =
     License :: OSI Approved :: BSD License
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: CPython
@@ -23,7 +22,7 @@ keywords = sleep, ecg, qrs, peak
 [options]
 include_package_data = True
 packages = find_namespace:
-python_requires = >=3.9
+python_requires = >=3.10
 install_requires =
     numpy>=1.20.0
     PyYAML>=5.4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,6 @@ maintainer_email = clemens.brunner@gmail.com
 classifiers =
     License :: OSI Approved :: BSD License
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
@@ -24,7 +23,7 @@ keywords = sleep, ecg, qrs, peak
 [options]
 include_package_data = True
 packages = find_namespace:
-python_requires = >=3.8
+python_requires = >=3.9
 install_requires =
     numpy>=1.20.0
     PyYAML>=5.4.0

--- a/sleepecg/classification.py
+++ b/sleepecg/classification.py
@@ -4,8 +4,6 @@
 
 """Functions related to classifier training and evaluation."""
 
-from __future__ import annotations
-
 import shutil
 from dataclasses import dataclass
 from pathlib import Path

--- a/sleepecg/config.py
+++ b/sleepecg/config.py
@@ -4,8 +4,6 @@
 
 """Functions for getting and setting configuration values."""
 
-from __future__ import annotations
-
 from pathlib import Path
 from typing import Any, Optional
 

--- a/sleepecg/feature_extraction.py
+++ b/sleepecg/feature_extraction.py
@@ -4,8 +4,6 @@
 
 """Functions and utilities related to feature extraction."""
 
-from __future__ import annotations
-
 import warnings
 from typing import Iterable, Optional
 

--- a/sleepecg/heartbeats.py
+++ b/sleepecg/heartbeats.py
@@ -4,8 +4,6 @@
 
 """Heartbeat detection and detector evaluation."""
 
-from __future__ import annotations
-
 import warnings
 from typing import NamedTuple
 

--- a/sleepecg/io/ecg_readers.py
+++ b/sleepecg/io/ecg_readers.py
@@ -4,8 +4,6 @@
 
 """Functions for reading datasets containing ECG and beat annotations."""
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Iterator, Optional

--- a/sleepecg/io/gudb.py
+++ b/sleepecg/io/gudb.py
@@ -4,8 +4,6 @@
 
 """Utilities for downloading GUDB data."""
 
-from __future__ import annotations
-
 from pathlib import Path
 from typing import Optional
 

--- a/sleepecg/io/nsrr.py
+++ b/sleepecg/io/nsrr.py
@@ -4,8 +4,6 @@
 
 """Interface for listing and downloading NSRR (sleepdata.org) data."""
 
-from __future__ import annotations
-
 from fnmatch import fnmatch
 from json.decoder import JSONDecodeError
 from pathlib import Path

--- a/sleepecg/io/physionet.py
+++ b/sleepecg/io/physionet.py
@@ -4,8 +4,6 @@
 
 """Simple interface for downloading PhysioNet data."""
 
-from __future__ import annotations
-
 import fnmatch
 from pathlib import Path
 from typing import Iterable

--- a/sleepecg/io/sleep_readers.py
+++ b/sleepecg/io/sleep_readers.py
@@ -4,8 +4,6 @@
 
 """Read datasets containing ECG data and sleep stage annotations."""
 
-from __future__ import annotations
-
 import csv
 import datetime
 from dataclasses import dataclass

--- a/sleepecg/plot.py
+++ b/sleepecg/plot.py
@@ -4,8 +4,6 @@
 
 """Plotting functions."""
 
-from __future__ import annotations
-
 from itertools import cycle
 from typing import TYPE_CHECKING, Optional
 

--- a/sleepecg/test/test_sleep_readers.py
+++ b/sleepecg/test/test_sleep_readers.py
@@ -4,8 +4,6 @@
 
 """Tests for sleep data reader functions."""
 
-from __future__ import annotations
-
 import datetime
 from pathlib import Path
 

--- a/sleepecg/utils.py
+++ b/sleepecg/utils.py
@@ -4,8 +4,6 @@
 
 """Utility functions."""
 
-from __future__ import annotations
-
 import datetime
 import warnings
 from typing import Any, Callable, Iterable, TypeVar


### PR DESCRIPTION
Just checking if this is still necessary. It looks like we can remove them with Python >= 3.10.

### Python 3.8
```
      def _read_yaml(path: Path) -> dict[str, Any]:
  E   TypeError: 'type' object is not subscriptable
```

### Python 3.9

```
      data_dir: str | Path = ".",
  E   TypeError: unsupported operand type(s) for |: 'type' and 'type'
```