### PR TITLE
Fix warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ add_ignore = 'D105'
 [tool.pytest.ini_options]
 markers = ['c_extension']
 filterwarnings = [
+    'error',
     'ignore:.*sample_rate:DeprecationWarning:pyedflib',
     'ignore:.*pkg_resources:DeprecationWarning',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,3 +35,4 @@ add_ignore = 'D105'
 
 [tool.pytest.ini_options]
 markers = ['c_extension']
+filterwarnings = ['ignore:sample_rate:DeprecationWarning:pyedflib.*']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,4 +35,7 @@ add_ignore = 'D105'
 
 [tool.pytest.ini_options]
 markers = ['c_extension']
-filterwarnings = ['ignore:sample_rate:DeprecationWarning:pyedflib.*']
+filterwarnings = [
+    'ignore:.*sample_rate:DeprecationWarning:pyedflib',
+    'ignore:.*pkg_resources:DeprecationWarning',
+]

--- a/sleepecg/heartbeats.py
+++ b/sleepecg/heartbeats.py
@@ -636,5 +636,5 @@ def _thresholding_py(
 
 
 if "numba" in _available_backends:
-    _squared_moving_integration_numba = jit(_squared_moving_integration_py)
-    _thresholding_numba = jit(_thresholding_py)
+    _squared_moving_integration_numba = jit(_squared_moving_integration_py, nopython=True)
+    _thresholding_numba = jit(_thresholding_py, nopython=True)

--- a/sleepecg/test/test_heartbeat_detection.py
+++ b/sleepecg/test/test_heartbeat_detection.py
@@ -8,6 +8,7 @@ import sys
 
 import numpy as np
 import pytest
+
 try:
     from scipy.datasets import electrocardiogram  # SciPy ≥ 1.10
 except ImportError:

--- a/sleepecg/test/test_heartbeat_detection.py
+++ b/sleepecg/test/test_heartbeat_detection.py
@@ -8,7 +8,10 @@ import sys
 
 import numpy as np
 import pytest
-from scipy.misc import electrocardiogram
+try:
+    from scipy.datasets import electrocardiogram  # SciPy ≥ 1.10
+except ImportError:
+    from scipy.misc import electrocardiogram  # SciPy < 1.10
 from scipy.signal import resample_poly
 
 from sleepecg import compare_heartbeats, detect_heartbeats

--- a/sleepecg/test/test_sleep_readers.py
+++ b/sleepecg/test/test_sleep_readers.py
@@ -10,7 +10,10 @@ import datetime
 from pathlib import Path
 
 import numpy as np
-import scipy.misc
+try:
+    from scipy.datasets import electrocardiogram  # SciPy ≥ 1.10
+except ImportError:
+    from scipy.misc import electrocardiogram  # SciPy < 1.10
 from pyedflib import highlevel
 
 from sleepecg import SleepStage, read_mesa, read_shhs, read_slpdb
@@ -19,7 +22,7 @@ from sleepecg.io.sleep_readers import Gender
 
 def _dummy_nsrr_edf(filename: str, hours: float, ecg_channel: str):
     ECG_FS = 360
-    ecg_5_min = scipy.misc.electrocardiogram()
+    ecg_5_min = electrocardiogram()
     seconds = int(hours * 60 * 60)
     ecg = np.tile(ecg_5_min, int(np.ceil(seconds / 300)))[np.newaxis, : seconds * ECG_FS]
     signal_headers = highlevel.make_signal_headers([ecg_channel], sample_frequency=ECG_FS)

--- a/sleepecg/test/test_sleep_readers.py
+++ b/sleepecg/test/test_sleep_readers.py
@@ -10,6 +10,7 @@ import datetime
 from pathlib import Path
 
 import numpy as np
+
 try:
     from scipy.datasets import electrocardiogram  # SciPy ≥ 1.10
 except ImportError:


### PR DESCRIPTION
Trying to fix all warnings that occur in our tests. Not yet fully done, I need to ignore more DeprecationWarnings (that's the best we can do because they occur in external packages).