### PR TITLE
Test detect_heartbeats with numba backend on python 3.11

### DIFF
--- a/sleepecg/test/test_heartbeats.py
+++ b/sleepecg/test/test_heartbeats.py
@@ -4,8 +4,6 @@
 
 """Tests for heartbeat detection and detector evaluation."""
 
-import sys
-
 import numpy as np
 import pytest
 
@@ -31,19 +29,7 @@ def mitdb_234_MLII():
     return next(read_mitdb(records_pattern="234"))
 
 
-@pytest.mark.parametrize(
-    "backend",
-    [
-        "c",
-        pytest.param(
-            "numba",
-            marks=pytest.mark.skipif(
-                sys.version_info >= (3, 11), reason="numba does not support Python 3.11 yet"
-            ),
-        ),
-        "python",
-    ],
-)
+@pytest.mark.parametrize("backend", ["c", "numba", "python"])
 def test_detect_heartbeats(mitdb_234_MLII, backend):
     """Test heartbeat detection on mitdb:234:MLII."""
     record = mitdb_234_MLII


### PR DESCRIPTION
With numba now available for python3.11 (#147), we can stop skipping the detect_heartbeats test with numba backend.