### PR TITLE
Use official tensorflow package also on macOS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,7 @@ full = [  # complete package functionality
     "matplotlib >= 3.5.0",
     "mne >= 1.0.0",
     "numba >= 0.55.0",
-    "tensorflow >= 2.7.0; sys_platform != 'darwin'",
-    "tensorflow-macos >= 2.7.0; sys_platform == 'darwin' and python_version < '3.11'",
-    "tensorflow-metal >= 0.8.0; sys_platform == 'darwin' and python_version < '3.11'",
+    "tensorflow >= 2.7.0",
     "wfdb >= 3.4.0",
 ]
 
@@ -58,9 +56,7 @@ dev = [  # everything needed for development
     "pytest >= 6.2.0",
     "setuptools >= 56.0.0",
     "sphinx >= 4.1.0",
-    "tensorflow >= 2.7.0; sys_platform != 'darwin'",
-    "tensorflow-macos >= 2.7.0; sys_platform == 'darwin' and python_version < '3.11'",
-    "tensorflow-metal >= 0.8.0; sys_platform == 'darwin' and python_version < '3.11'",
+    "tensorflow >= 2.7.0",
     "wfdb >= 3.4.0",
 ]
 


### PR DESCRIPTION
Using `tensorflow` instead of Apple-maintained `tensorflow-macos` and `tensorflow-metal` avoids problems when installing and loading models. This means no GPU support for Macs, but if someone really wants to enable this, it can be done manually (which means we don't have to support it).