### PR TITLE
Update docs

### DIFF
--- a/docs/feature_extraction.md
+++ b/docs/feature_extraction.md
@@ -8,6 +8,10 @@ Group identifier: `hrv-time`
 
 All time domain HRV features are either derived from normal-to-normal (NN) intervals, from successive differences between NN intervals (SD), or from the [Poincaré plot (PP)](https://en.wikipedia.org/wiki/Poincar%C3%A9_plot).
 
+!!! note
+    
+    SleepECG expects time in *seconds* to compute features. Since many features like RMSSD are typically specified in *milliseconds* in the field of heart rate variability research. Therefore, SleepECG features need to be manually rescaled before comparing to millisecond-based features.
+
 |Feature|Description|Signal|
 |-|-|-|
 |`meanNN`|average normal-normal (NN) interval|NN|

--- a/docs/feature_extraction.md
+++ b/docs/feature_extraction.md
@@ -10,7 +10,7 @@ All time domain HRV features are either derived from normal-to-normal (NN) inter
 
 !!! note
     
-    SleepECG expects time in *seconds* to compute features. Since many features like RMSSD are typically specified in *milliseconds* in the field of heart rate variability research, SleepECG features need to be manually rescaled before comparing to millisecond-based features.
+    SleepECG expects time in *seconds* to compute features. Since many features like RMSSD are typically specified in *milliseconds* in the field of heart rate variability research, the resulting features need to be manually rescaled before comparing to millisecond-based features.
 
 |Feature|Description|Signal|
 |-|-|-|

--- a/docs/feature_extraction.md
+++ b/docs/feature_extraction.md
@@ -10,7 +10,7 @@ All time domain HRV features are either derived from normal-to-normal (NN) inter
 
 !!! note
     
-    SleepECG expects time in *seconds* to compute features. Since many features like RMSSD are typically specified in *milliseconds* in the field of heart rate variability research. Therefore, SleepECG features need to be manually rescaled before comparing to millisecond-based features.
+    SleepECG expects time in *seconds* to compute features. Since many features like RMSSD are typically specified in *milliseconds* in the field of heart rate variability research, SleepECG features need to be manually rescaled before comparing to millisecond-based features.
 
 |Feature|Description|Signal|
 |-|-|-|

--- a/sleepecg/io/ecg_readers.py
+++ b/sleepecg/io/ecg_readers.py
@@ -33,7 +33,7 @@ class ECGRecord:
     ecg : np.ndarray
         The ECG signal.
     fs : float
-        The sampling frequency.
+        The sampling frequency in Hz.
     annotation : np.ndarray
         Indices of annotated heartbeats.
     lead : str, optional


### PR DESCRIPTION
Clarify that time-based features use time in seconds and the sampling frequency is in Hz.