### PR TITLE
Replace flake8 with ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,0 @@
-[flake8]
-extend-ignore = E203
-max-line-length = 92
-max-doc-length = 92
-exclude =
-    ./build/*
-per-file-ignores = __init__.py:F401

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,18 +14,10 @@ repos:
     - id: mixed-line-ending
     - id: check-builtin-literals
 
-  - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.269
     hooks:
-    - id: flake8
-
-  - repo: https://github.com/pycqa/pydocstyle
-    rev: 6.3.0
-    hooks:
-    - id: pydocstyle
-      files: ^sleepecg/
-      additional_dependencies:
-      - tomli
+      - id: ruff
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.2.0

--- a/examples/benchmark/utils.py
+++ b/examples/benchmark/utils.py
@@ -10,11 +10,14 @@ import time
 from typing import Any, Iterator
 
 import numpy as np
+
 import sleepecg
 from sleepecg.io.ecg_readers import ECGRecord
 
 
 class HeartpyWarning(Warning):
+    """Warning for all Heartpy-related warnings."""
+
     pass
 
 

--- a/examples/try_ws_gru_mesa.py
+++ b/examples/try_ws_gru_mesa.py
@@ -1,5 +1,6 @@
 # %%
 import matplotlib.pyplot as plt
+
 from sleepecg import load_classifier, plot_hypnogram, read_slpdb, stage
 
 # The model was built using tensorflow 2.7, running on higher versions might create warnings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ full = [  # complete package functionality
 
 dev = [  # everything needed for development
     "black >= 22.6.0",
-    "flake8 >= 4.0.0",
     "joblib >= 1.0.0",
     "matplotlib >= 3.5.0",
     "mkdocs-material >= 8.4.0",
@@ -54,6 +53,7 @@ dev = [  # everything needed for development
     "pre-commit >= 2.13.0",
     "pyEDFlib >= 0.1.25",
     "pytest >= 6.2.0",
+    "ruff >= 0.0.263",
     "setuptools >= 56.0.0",
     "sphinx >= 4.1.0",
     "tensorflow >= 2.7.0",
@@ -106,10 +106,6 @@ warn_unreachable = true
 strict_equality = true
 pretty = true
 
-[tool.pydocstyle]
-convention = "numpy"
-add_ignore = "D105"
-
 [tool.pytest.ini_options]
 markers = ["c_extension"]
 filterwarnings = [
@@ -117,6 +113,19 @@ filterwarnings = [
     'ignore:.*sample_rate:DeprecationWarning:pyedflib',
     'ignore:.*pkg_resources:DeprecationWarning',
 ]
+
+[tool.ruff]
+select = ["D", "E", "F", "I", "W"]
+line-length = 92
+ignore = ["D105"]
+exclude = ["setup.py"]
+
+[tool.ruff.per-file-ignores]
+"__init__.py" = ["F401"]
+"**/examples/*.py" = ["D100"]
+
+[tool.ruff.pydocstyle]
+convention = "numpy"
 
 [tool.setuptools.dynamic]
 version = {attr = "sleepecg.__version__"}

--- a/sleepecg/io/ecg_readers.py
+++ b/sleepecg/io/ecg_readers.py
@@ -17,10 +17,10 @@ if TYPE_CHECKING:
     import matplotlib.pyplot as plt
 
 from sleepecg.config import get_config
-from sleepecg.plot import plot_ecg
 from sleepecg.io.gudb import _GUDB_MD5
 from sleepecg.io.physionet import _list_physionet, download_physionet
 from sleepecg.io.utils import _download_file
+from sleepecg.plot import plot_ecg
 
 
 @dataclass


### PR DESCRIPTION
This replaces flake8 with ruff, which is much faster and combines multiple tools (such as pydocstyle).