### PR TITLE
Clean .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,1 @@
-**/__pycache__/
-!/.gitignore
-**/.ipynb_checkpoints/
-.idea
-.vscode
-.mypy_cache
-examples/datasets/
-examples/benchmark/results/
-build
-dist
-site
-*.egg-info
-*.pyd
 *.so

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 *.so
+.mypy_cache/
+.pytest_cache/
+.ruff_cache/
+__pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
+*.pyd
 *.so
 .mypy_cache/
 .pytest_cache/
 .ruff_cache/
 __pycache__/
+site/
+sleepecg.egg-info/


### PR DESCRIPTION
I think we don't need to foresee every file we might want to ignore depending on which IDE or other tools someone uses. These should go into `.gitignore_global`, so currently only `*.so` remains (because this is part of the package, but should not be under source control).

For example, my `.gitignore_global` looks like this:

```
.DS_Store
.idea
.vscode
.venv
.envrc
.direnv
__pycache__
.mypy_cache
.pytest_cache
.ruff_cache
.ipynb_checkpoints
*.egg-info
```

@hofaflo WDYT?