### PR TITLE
Remove sphinx from dev requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,6 @@ dev = [  # everything needed for development
     "pytest >= 6.2.0",
     "ruff >= 0.0.263",
     "setuptools >= 56.0.0",
-    "sphinx >= 4.1.0",
     "tensorflow >= 2.7.0",
     "wfdb >= 3.4.0",
 ]


### PR DESCRIPTION
I forgot to do this when switching to Mkdocs.