### PR TITLE
Remove system packages from RTD build

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -12,9 +12,8 @@ mkdocs:
   configuration: mkdocs.yml
 
 python:
-  system_packages: true
   install:
   - method: pip
-    path: "."
+    path: .
     extra_requirements:
       - doc


### PR DESCRIPTION
The `system_packages` setting is [deprecated](https://blog.readthedocs.com/drop-support-system-packages/), and I think we have never needed it in the first place.