### PR TITLE
Fix sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 graft .github
-graft doc
+graft docs
 graft examples
 graft sleepecg
 global-exclude *.so
@@ -9,4 +9,5 @@ include .gitignore
 include .pre-commit-config.yaml
 include CHANGELOG.md
 include CONTRIBUTING.md
+include mkdocs.yml
 include readthedocs.yml


### PR DESCRIPTION
Fixes #196. I decided to include all files under source control, because (1) it is easier, (2) it's probably a good thing to have an archive (snapshot) of all sources for every release, and (3) I think that's what we originally wanted to do (the missing `docs` folder was actually a bug, because we included a `doc` folder, which does not exist because we renamed it to `docs` at some point but forgot to adapt `MANIFEST.in`).

So hopefully, you are OK with this sudden change of mind. If so, please feel free to merge.