### PR TITLE
Enable Numba on Python 3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [UNRELEASED] - YYYY-MM-DD
+### Added
+- Add support for Python 3.12 ([#207](https://github.com/cbrnr/sleepecg/pull/207) by [Clemens Brunner](https://github.com/cbrnr))
 
 ## [0.5.6] - 2023-12-22
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
     "Typing :: Typed",
 ]
@@ -35,7 +36,7 @@ full = [  # complete package functionality
     "edfio >= 0.1.1",
     "joblib >= 1.0.0",
     "matplotlib >= 3.5.0",
-    "numba >= 0.55.0; python_version < '3.12'",
+    "numba >= 0.59.0",
     "tensorflow >= 2.7.0; python_version < '3.12'",
     "wfdb >= 3.4.0",
 ]
@@ -47,7 +48,7 @@ dev = [  # everything needed for development
     "mkdocs-material >= 8.4.0",
     "mkdocstrings-python >= 0.7.1",
     "mypy >= 0.991",
-    "numba >= 0.55.0; python_version < '3.12'",
+    "numba >= 0.59.0",
     "pre-commit >= 2.13.0",
     "pytest >= 6.2.0",
     "ruff >= 0.1.8",
@@ -63,7 +64,7 @@ doc = [  # RTD uses this when building the documentation
 
 cibw = [  # cibuildwheel uses this for running the test suite
     "edfio >= 0.1.1",
-    "numba >= 0.55.0; python_version < '3.12'",
+    "numba >= 0.59.0",
     "wfdb >= 3.4.0",
 ]
 


### PR DESCRIPTION
Numba 0.59 added support for Python 3.12, so let's see if this works.