### PR TITLE
Refresh project with latest style

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
+    rev: v1.10.0
     hooks:
     - id: mypy
       exclude: ^sleepecg/test/|^examples

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.1
+    rev: v0.4.4
     hooks:
       - id: ruff
         args: [ --fix ]

--- a/examples/benchmark/utils.py
+++ b/examples/benchmark/utils.py
@@ -7,7 +7,8 @@
 from __future__ import annotations
 
 import time
-from typing import Any, Iterator
+from collections.abc import Iterator
+from typing import Any
 
 import numpy as np
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,13 @@ authors = [
     {name = "Florian Hofer", email = "hofaflo@gmail.com"},
     {name = "Clemens Brunner", email = "clemens.brunner@gmail.com"},
 ]
+readme = "README.md"
 requires-python = ">=3.9"
 classifiers = [
     "License :: OSI Approved :: BSD License",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: MacOS :: MacOS X",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -29,7 +33,7 @@ dependencies = [
     "scipy >= 1.7.0",
     "tqdm >= 4.60.0",
 ]
-dynamic = ["version", "readme"]
+dynamic = ["version"]
 
 [project.optional-dependencies]
 full = [  # complete package functionality
@@ -37,24 +41,18 @@ full = [  # complete package functionality
     "joblib >= 1.0.0",
     "matplotlib >= 3.5.0",
     "numba >= 0.59.0",
-    "tensorflow >= 2.7.0; python_version < '3.12'",
+    "tensorflow >= 2.7.0",
     "wfdb >= 3.4.0",
 ]
 
 dev = [  # everything needed for development
-    "edfio >= 0.1.1",
-    "joblib >= 1.0.0",
-    "matplotlib >= 3.5.0",
-    "mkdocs-material >= 8.4.0",
-    "mkdocstrings-python >= 0.7.1",
+    "sleepecg[doc]",
+    "sleepecg[full]",
     "mypy >= 0.991",
-    "numba >= 0.59.0",
     "pre-commit >= 2.13.0",
     "pytest >= 6.2.0",
-    "ruff >= 0.1.8",
+    "ruff >= 0.4.0",
     "setuptools >= 56.0.0",
-    "tensorflow >= 2.7.0; python_version < '3.12'",
-    "wfdb >= 3.4.0",
 ]
 
 doc = [  # RTD uses this when building the documentation
@@ -108,16 +106,18 @@ filterwarnings = [
 ]
 
 [tool.ruff]
-select = ["D", "E", "F", "I", "W"]
 line-length = 92
-ignore = ["D105"]
 exclude = ["setup.py"]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint]
+select = ["D", "E", "F", "I", "W", "UP"]
+ignore = ["D105"]
+
+[tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
 "**/examples/*.py" = ["D100"]
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "numpy"
 
 [tool.setuptools.dynamic]

--- a/sleepecg/classification.py
+++ b/sleepecg/classification.py
@@ -10,7 +10,7 @@ import shutil
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, Optional, Protocol
+from typing import Any, Protocol
 from zipfile import ZipFile
 
 import numpy as np
@@ -90,7 +90,7 @@ def prepare_data_keras(
     return features_padded, stages_padded_onehot, sample_weight
 
 
-def print_class_balance(stages: np.ndarray, stages_mode: Optional[str] = None) -> None:
+def print_class_balance(stages: np.ndarray, stages_mode: str | None = None) -> None:
     """
     Print the number of samples and percentages of each class in `stages`.
 
@@ -131,8 +131,8 @@ def save_classifier(
     model: Any,
     stages_mode: str,
     feature_extraction_params: dict[str, Any],
-    mask_value: Optional[int] = None,
-    classifiers_dir: Optional[str | Path] = None,
+    mask_value: int | None = None,
+    classifiers_dir: str | Path | None = None,
 ) -> None:
     """
     Save a trained classifier to disk.
@@ -191,11 +191,9 @@ def save_classifier(
 
 
 class _Model(Protocol):
-    def fit(self, X: np.ndarray, y: np.ndarray) -> None:
-        ...
+    def fit(self, X: np.ndarray, y: np.ndarray) -> None: ...
 
-    def predict(self, X: np.ndarray) -> np.ndarray:
-        ...
+    def predict(self, X: np.ndarray) -> np.ndarray: ...
 
 
 @dataclass
@@ -228,8 +226,8 @@ class SleepClassifier:
     stages_mode: str
     feature_extraction_params: dict[str, Any]
     model_type: str
-    mask_value: Optional[int] = None
-    source_file: Optional[Path] = None
+    mask_value: int | None = None
+    source_file: Path | None = None
 
     def __repr__(self) -> str:
         if self.source_file is not None:
@@ -251,7 +249,7 @@ class SleepClassifier:
 
 def load_classifier(
     name: str,
-    classifiers_dir: Optional[str | Path] = None,
+    classifiers_dir: str | Path | None = None,
     silence_tf_messages: bool = True,
 ) -> SleepClassifier:
     """
@@ -322,7 +320,7 @@ def load_classifier(
     )
 
 
-def list_classifiers(classifiers_dir: Optional[str | Path] = None) -> None:
+def list_classifiers(classifiers_dir: str | Path | None = None) -> None:
     """
     List available classifiers.
 

--- a/sleepecg/feature_extraction.py
+++ b/sleepecg/feature_extraction.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import Iterable, Optional
+from collections.abc import Iterable
 
 import numpy as np
 from numpy.lib.stride_tricks import sliding_window_view
@@ -505,8 +505,8 @@ def _check_frequencydomain_window_time(window_time: int, feature_ids: list[str])
 
 def preprocess_rri(
     rri: np.ndarray,
-    min_rri: Optional[float] = None,
-    max_rri: Optional[float] = None,
+    min_rri: float | None = None,
+    max_rri: float | None = None,
 ) -> np.ndarray:
     """
     Replace invalid RRI samples with `np.nan`.
@@ -678,10 +678,10 @@ def extract_features(
     lookback: int = 0,
     lookforward: int = 30,
     sleep_stage_duration: int = 30,
-    feature_selection: Optional[list[str]] = None,
+    feature_selection: list[str] | None = None,
     fs_rri_resample: float = 4,
-    min_rri: Optional[float] = None,
-    max_rri: Optional[float] = None,
+    min_rri: float | None = None,
+    max_rri: float | None = None,
     max_nans: float = 0,
     n_jobs: int = 1,
 ) -> tuple[list[np.ndarray], list[np.ndarray | None], list[str]]:

--- a/sleepecg/io/ecg_readers.py
+++ b/sleepecg/io/ecg_readers.py
@@ -6,9 +6,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterator, Optional
+from typing import TYPE_CHECKING
 
 import numpy as np
 from tqdm import tqdm
@@ -45,8 +46,8 @@ class ECGRecord:
     ecg: np.ndarray
     fs: float
     annotation: np.ndarray
-    lead: Optional[str] = None
-    id: Optional[str] = None
+    lead: str | None = None
+    id: str | None = None
 
     def export(self, filename: str | Path) -> None:
         """
@@ -59,7 +60,7 @@ class ECGRecord:
         """
         export_ecg_record(self, filename)
 
-    def plot(self, **kwargs: np.ndarray) -> tuple["plt.Figure", "plt.Axes"]:
+    def plot(self, **kwargs: np.ndarray) -> tuple[plt.Figure, plt.Axes]:
         """
         Plot ECG time series with optional markers.
 
@@ -107,7 +108,7 @@ def export_ecg_record(record: ECGRecord, filename: str | Path) -> None:
 def read_ltdb(
     records_pattern: str = "*",
     offline: bool = False,
-    data_dir: Optional[str | Path] = None,
+    data_dir: str | Path | None = None,
 ) -> Iterator[ECGRecord]:
     """
     Lazily read records from [LTDB](https://physionet.org/content/ltdb/).
@@ -138,7 +139,7 @@ def read_ltdb(
 def read_mitdb(
     records_pattern: str = "*",
     offline: bool = False,
-    data_dir: Optional[str | Path] = None,
+    data_dir: str | Path | None = None,
 ) -> Iterator[ECGRecord]:
     """
     Lazily read records from [MITDB](https://physionet.org/content/mitdb/).
@@ -235,7 +236,7 @@ def _read_mitbih(
 
 def read_gudb(
     offline: bool = False,
-    data_dir: Optional[str | Path] = None,
+    data_dir: str | Path | None = None,
 ) -> Iterator[ECGRecord]:
     """
     Lazily read records from [GUDB](https://berndporr.github.io/ECG-GUDB/).

--- a/sleepecg/io/gudb.py
+++ b/sleepecg/io/gudb.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional
 
 from sleepecg.config import get_config
 from sleepecg.io.utils import _calculate_checksum
@@ -370,7 +369,7 @@ _GUDB_MD5 = {
 }
 
 
-def _generate_gudb_md5(data_dir: Optional[str | Path] = None) -> dict[str, str]:
+def _generate_gudb_md5(data_dir: str | Path | None = None) -> dict[str, str]:
     """
     Compute checksums for files in GUDB.
 

--- a/sleepecg/io/physionet.py
+++ b/sleepecg/io/physionet.py
@@ -7,8 +7,8 @@
 from __future__ import annotations
 
 import fnmatch
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable
 
 from tqdm import tqdm
 

--- a/sleepecg/io/sleep_readers.py
+++ b/sleepecg/io/sleep_readers.py
@@ -8,10 +8,11 @@ from __future__ import annotations
 
 import csv
 import datetime
+from collections.abc import Iterator
 from dataclasses import dataclass
 from enum import IntEnum
 from pathlib import Path
-from typing import Iterator, NamedTuple, Optional
+from typing import NamedTuple
 from xml.etree import ElementTree
 
 import numpy as np
@@ -60,9 +61,9 @@ class SubjectData:
         The subject's weight in kg, by default `None`.
     """
 
-    gender: Optional[int] = None
-    age: Optional[int] = None
-    weight: Optional[float] = None
+    gender: int | None = None
+    age: int | None = None
+    weight: float | None = None
 
 
 @dataclass
@@ -87,12 +88,12 @@ class SleepRecord:
         Dataclass containing subject data (such as gender or age), by default `None`.
     """
 
-    sleep_stages: Optional[np.ndarray] = None
-    sleep_stage_duration: Optional[int] = None
-    id: Optional[str] = None
-    recording_start_time: Optional[datetime.time] = None
-    heartbeat_times: Optional[np.ndarray] = None
-    subject_data: Optional[SubjectData] = None
+    sleep_stages: np.ndarray | None = None
+    sleep_stage_duration: int | None = None
+    id: str | None = None
+    recording_start_time: datetime.time | None = None
+    heartbeat_times: np.ndarray | None = None
+    subject_data: SubjectData | None = None
 
 
 class _ParseNsrrXmlResult(NamedTuple):
@@ -167,7 +168,7 @@ def read_mesa(
     heartbeats_source: str = "annotation",
     offline: bool = False,
     keep_edfs: bool = False,
-    data_dir: Optional[str | Path] = None,
+    data_dir: str | Path | None = None,
 ) -> Iterator[SleepRecord]:
     """
     Lazily read records from [MESA](https://sleepdata.org/datasets/mesa).
@@ -362,7 +363,7 @@ def read_mesa(
 def read_slpdb(
     records_pattern: str = "*",
     offline: bool = False,
-    data_dir: Optional[str | Path] = None,
+    data_dir: str | Path | None = None,
 ) -> Iterator[SleepRecord]:
     """
     Lazily read records from [SLPDB](https://physionet.org/content/slpdb).
@@ -475,7 +476,7 @@ def read_shhs(
     heartbeats_source: str = "annotation",
     offline: bool = False,
     keep_edfs: bool = False,
-    data_dir: Optional[str | Path] = None,
+    data_dir: str | Path | None = None,
 ) -> Iterator[SleepRecord]:
     """
     Lazily read records from [SHHS](https://sleepdata.org/datasets/shhs).

--- a/sleepecg/utils.py
+++ b/sleepecg/utils.py
@@ -6,8 +6,9 @@
 
 import datetime
 import warnings
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Callable, Iterable, TypeVar
+from typing import Any, Callable, TypeVar
 
 import numpy as np
 


### PR DESCRIPTION
This PR simplifies `pyproject.toml` and uses `|` for type annotations. These are only available for Python ≥ 3.10, but we use them via `__future__`. Once we drop support for Python 3.9, these `__future__` imports can be removed.