### PR TITLE
Support storing nsrr_token in config or environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Fix `plot_ecg` for newer versions of Matplotlib ([#225](https://github.com/cbrnr/sleepecg/pull/225) by [Clemens Brunner](https://github.com/cbrnr))
 
 ### Added
-- Added support to store NSRR token in environment variable or user config ([#243](https://github.com/cbrnr/sleepecg/pull/243) by [Simon Pusterhofer](https://github.com/simon-p-2000))
+- Add support to store NSRR token in environment variable or user config ([#243](https://github.com/cbrnr/sleepecg/pull/243) by [Simon Pusterhofer](https://github.com/simon-p-2000))
 
 ## [0.5.8] - 2024-05-21
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 ## [UNRELEASED] - YYYY-MM-DD
+### Added
+- Add support to store NSRR token in environment variable or user config ([#243](https://github.com/cbrnr/sleepecg/pull/243) by [Simon Pusterhofer](https://github.com/simon-p-2000))
+
 ### Changed
 - Split `get_config` function into `get_config` and `get_config_value` to get the entire configuration (as a dictionary) or an individual configuration key, respectively ([#229](https://github.com/cbrnr/sleepecg/pull/225) by [Clemens Brunner](https://github.com/cbrnr))
 
 ### Fixed
 - Fix `plot_ecg` for newer versions of Matplotlib ([#225](https://github.com/cbrnr/sleepecg/pull/225) by [Clemens Brunner](https://github.com/cbrnr))
-
-### Added
-- Add support to store NSRR token in environment variable or user config ([#243](https://github.com/cbrnr/sleepecg/pull/243) by [Simon Pusterhofer](https://github.com/simon-p-2000))
 
 ## [0.5.8] - 2024-05-21
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Fixed
 - Fix `plot_ecg` for newer versions of Matplotlib ([#225](https://github.com/cbrnr/sleepecg/pull/225) by [Clemens Brunner](https://github.com/cbrnr))
 
+### Added
+- Added support to store NSRR token in environment variable or user config ([#243](https://github.com/cbrnr/sleepecg/pull/243) by [Simon Pusterhofer](https://github.com/simon-p-2000))
+
 ## [0.5.8] - 2024-05-21
 ### Changed
 - Switch to Keras 3 classifiers ([#217](https://github.com/cbrnr/sleepecg/pull/217) by [Clemens Brunner](https://github.com/cbrnr))

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -41,13 +41,6 @@ mesa = read_mesa()  # note that this is a generator
 ```
 
 Instead of always using [`set_nsrr_token()`](sleepecg.set_nsrr_token), you can set the NSRR token via [`set_config(nsrr_token="YOUR_TOKEN")`](sleepecg.set_config) or as an environment variable (`NSRR_TOKEN`).
-Setting the NSRR token in the config file is done via  [`config.py`](https://github.com/cbrnr/sleepecg/blob/main/src/sleepecg/config.py).
-The following code snippet shows how the set the NSRR token in the config file:
-
-```python
-from sleepecg.config import set_config 
-set_config(nsrr_token="your_nsrr_token")
-```
 
 Since the NSRR token can be set in multiple ways, a priority list is defined as such:
 1. NSRR token set via [`set_nsrr_token()`][sleepecg.set_nsrr_token]

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -42,12 +42,13 @@ mesa = read_mesa()  # note that this is a generator
 
 Instead of always using [`set_nsrr_token()`](sleepecg.set_nsrr_token), you can set the NSRR token via [`set_config(nsrr_token="YOUR_TOKEN")`](sleepecg.set_config) or as an environment variable (`NSRR_TOKEN`).
 
-Since the NSRR token can be set in multiple ways, a priority list is defined as such:
-1. NSRR token set via [`set_nsrr_token()`][sleepecg.set_nsrr_token]
-2. NSRR token set as an environment variable
-3. NSRR token set in the config
+SleepECG checks for the NSRR token in the following order:
 
-So if for instance the NSRR token was set both via 1. and 3. the NSRR token set via 1. is used.
+1. Token set via [`set_nsrr_token()`][sleepecg.set_nsrr_token]
+2. Token set via environment variable `NSRR_TOKEN`
+3. Token set in the user configuration
+
+For example, if the token is set by both method 1 *and* method 3, method 1 takes precedence.
 
 You can also select a subset of records from a dataset. This example will download and read all records having IDs starting with `00` (i.e. records `0001`–`0099`):
 

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -40,6 +40,23 @@ set_nsrr_token("<your-download-token-here>")
 mesa = read_mesa()  # note that this is a generator
 ```
 
+As an alternative to always using the 'set_nsrr_token' function, the NSRR token can be set either in the config file
+(nsrr_token) or as an environment variable (NSRR_TOKEN). How to set an environment variable depends on your operating system and should be looked up in a relevant manual.
+Setting the NSRR token in the config file is done via  [`config.py`](https://github.com/cbrnr/sleepecg/blob/main/src/sleepecg/config.py).
+The following code snippet shows how the set the NSRR token in the config file:
+
+```python
+from sleepecg.config import set_config 
+set_config(nsrr_token="your_nsrr_token")
+```
+
+Since the NSRR token can be set in multiple ways, a priority list is defined as such:
+1. NSRR token set via [`set_nsrr_token()`][sleepecg.set_nsrr_token]
+2. NSRR token set as an environment variable
+3. NSRR token set in the config
+
+So if for instance the NSRR token was set both via 1. and 3. the NSRR token set via 1. is used.
+
 You can also select a subset of records from a dataset. This example will download and read all records having IDs starting with `00` (i.e. records `0001`–`0099`):
 
 ```python

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -40,8 +40,7 @@ set_nsrr_token("<your-download-token-here>")
 mesa = read_mesa()  # note that this is a generator
 ```
 
-As an alternative to always using the 'set_nsrr_token' function, the NSRR token can be set either in the config file
-(nsrr_token) or as an environment variable (NSRR_TOKEN). How to set an environment variable depends on your operating system and should be looked up in a relevant manual.
+Instead of always using [`set_nsrr_token()`](sleepecg.set_nsrr_token), you can set the NSRR token via [`set_config(nsrr_token="YOUR_TOKEN")`](sleepecg.set_config) or as an environment variable (`NSRR_TOKEN`).
 Setting the NSRR token in the config file is done via  [`config.py`](https://github.com/cbrnr/sleepecg/blob/main/src/sleepecg/config.py).
 The following code snippet shows how the set the NSRR token in the config file:
 

--- a/src/sleepecg/config.yml
+++ b/src/sleepecg/config.yml
@@ -1,2 +1,3 @@
 data_dir: ~/.sleepecg/datasets
 classifiers_dir: ~/.sleepecg/classifiers
+nsrr_token:

--- a/src/sleepecg/io/nsrr.py
+++ b/src/sleepecg/io/nsrr.py
@@ -63,9 +63,9 @@ def _get_nsrr_url(db_slug: str) -> str:
         The download URL.
     """
     global _nsrr_token
-    if not _nsrr_token:
+    if _nsrr_token is None:
         _nsrr_token = os.environ.get("nsrr_token")
-        if not _nsrr_token:
+        if _nsrr_token is None:
             try:
                 from sleepecg import get_config_value
 

--- a/src/sleepecg/io/nsrr.py
+++ b/src/sleepecg/io/nsrr.py
@@ -11,6 +11,7 @@ from json.decoder import JSONDecodeError
 from pathlib import Path
 
 import requests
+import os
 from tqdm import tqdm
 
 from sleepecg.io.utils import _download_file
@@ -61,8 +62,16 @@ def _get_nsrr_url(db_slug: str) -> str:
     str
         The download URL.
     """
-    if _nsrr_token is None:
-        raise RuntimeError("NSRR token not set, use `sleepecg.set_nsrr_token(<token>)`!")
+    global _nsrr_token
+    if not _nsrr_token:
+        _nsrr_token = os.environ.get("nsrr_token")
+        if not _nsrr_token:
+            try:
+                from sleepecg import get_config_value
+                _nsrr_token = get_config_value("nsrr_token")
+            except ValueError:
+                raise RuntimeError("NSRR token not set, use `sleepecg.set_nsrr_token(<token>)`, set the token in the "
+                                   "'config.yml' file or set an environment variable 'nsrr_token'!")
     return f"https://sleepdata.org/datasets/{db_slug}/files/a/{_nsrr_token}/m/sleepecg/"
 
 

--- a/src/sleepecg/io/nsrr.py
+++ b/src/sleepecg/io/nsrr.py
@@ -65,9 +65,9 @@ def _get_nsrr_url(db_slug: str) -> str:
     """
     global _nsrr_token
     if (
-            _nsrr_token := _nsrr_token
-                           or os.environ.get("NSRR_TOKEN")
-                           or get_config_value("nsrr_token")
+        _nsrr_token := _nsrr_token
+        or os.environ.get("NSRR_TOKEN")
+        or get_config_value("nsrr_token")
     ) is None:
         raise RuntimeError(
             "NSRR token not set, use `sleepecg.set_nsrr_token(<token>)`, set the token "

--- a/src/sleepecg/io/nsrr.py
+++ b/src/sleepecg/io/nsrr.py
@@ -68,10 +68,14 @@ def _get_nsrr_url(db_slug: str) -> str:
         if not _nsrr_token:
             try:
                 from sleepecg import get_config_value
+
                 _nsrr_token = get_config_value("nsrr_token")
             except ValueError:
-                raise RuntimeError("NSRR token not set, use `sleepecg.set_nsrr_token(<token>)`, set the token in the "
-                                   "'config.yml' file or set an environment variable 'nsrr_token'!")
+                raise RuntimeError(
+                    "NSRR token not set, use `sleepecg.set_nsrr_token(<token>)`, set the "
+                    "token in the 'config.yml' file or set an environment variable "
+                    "'nsrr_token'!"
+                )
     return f"https://sleepdata.org/datasets/{db_slug}/files/a/{_nsrr_token}/m/sleepecg/"
 
 

--- a/src/sleepecg/io/nsrr.py
+++ b/src/sleepecg/io/nsrr.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import requests
 from tqdm import tqdm
 
+from sleepecg.config import get_config_value
 from sleepecg.io.utils import _download_file
 
 _nsrr_token = None
@@ -64,18 +65,17 @@ def _get_nsrr_url(db_slug: str) -> str:
     """
     global _nsrr_token
     if _nsrr_token is None:
-        _nsrr_token = os.environ.get("nsrr_token")
-        if _nsrr_token is None:
-            try:
-                from sleepecg import get_config_value
-
-                _nsrr_token = get_config_value("nsrr_token")
-            except ValueError:
-                raise RuntimeError(
-                    "NSRR token not set, use `sleepecg.set_nsrr_token(<token>)`, set the "
-                    "token in the 'config.yml' file or set an environment variable "
-                    "'nsrr_token'!"
-                )
+        _nsrr_token = os.environ.get("NSRR_TOKEN")
+        if (
+            _nsrr_token := _nsrr_token
+            or os.environ.get("NSRR_TOKEN")
+            or get_config_value("nsrr_token")
+        ) is None:
+            raise RuntimeError(
+                "NSRR token not set, use `sleepecg.set_nsrr_token(<token>)`, set the "
+                "token in the 'config.yml' file or set an environment variable "
+                "'NSRR_TOKEN'!"
+            )
     return f"https://sleepdata.org/datasets/{db_slug}/files/a/{_nsrr_token}/m/sleepecg/"
 
 

--- a/src/sleepecg/io/nsrr.py
+++ b/src/sleepecg/io/nsrr.py
@@ -64,18 +64,15 @@ def _get_nsrr_url(db_slug: str) -> str:
         The download URL.
     """
     global _nsrr_token
-    if _nsrr_token is None:
-        _nsrr_token = os.environ.get("NSRR_TOKEN")
-        if (
+    if (
             _nsrr_token := _nsrr_token
-            or os.environ.get("NSRR_TOKEN")
-            or get_config_value("nsrr_token")
-        ) is None:
-            raise RuntimeError(
-                "NSRR token not set, use `sleepecg.set_nsrr_token(<token>)`, set the "
-                "token in the 'config.yml' file or set an environment variable "
-                "'NSRR_TOKEN'!"
-            )
+                           or os.environ.get("NSRR_TOKEN")
+                           or get_config_value("nsrr_token")
+    ) is None:
+        raise RuntimeError(
+            "NSRR token not set, use `sleepecg.set_nsrr_token(<token>)`, set the token "
+            "in the configuration, or set an environment variable NSRR_TOKEN."
+        )
     return f"https://sleepdata.org/datasets/{db_slug}/files/a/{_nsrr_token}/m/sleepecg/"
 
 

--- a/src/sleepecg/io/nsrr.py
+++ b/src/sleepecg/io/nsrr.py
@@ -6,12 +6,12 @@
 
 from __future__ import annotations
 
+import os
 from fnmatch import fnmatch
 from json.decoder import JSONDecodeError
 from pathlib import Path
 
 import requests
-import os
 from tqdm import tqdm
 
 from sleepecg.io.utils import _download_file

--- a/tests/test_nsrr.py
+++ b/tests/test_nsrr.py
@@ -15,30 +15,23 @@ from sleepecg.io.nsrr import _get_nsrr_url
 
 @pytest.fixture(autouse=True)
 def temp_test_config(tmp_path):
-    """Create, use and delete a temporary user config file for testing."""
-    # setup
+    """Create, use, and delete a temporary user config file for testing."""
     user_config_path_backup = sleepecg.config._USER_CONFIG_PATH
     sleepecg.config._USER_CONFIG_PATH = tmp_path / "testconfig.yml"
-
-    # execute test
     yield
-
-    # cleanup
     sleepecg.config._USER_CONFIG_PATH = user_config_path_backup
 
 
 def test_get_nsrr_url_no_nsrr_token_set(monkeypatch):
-    """Tests the get_nsrr_url method with no nsrr_token set."""
-    # simulate blank environment variable
-    monkeypatch.delenv("nsrr_url", raising=False)
+    """Test the _get_nsrr_url method with no token set."""
+    monkeypatch.delenv("nsrr_token", raising=False)
 
     with pytest.raises(RuntimeError, match="NSRR token not set"):
         _get_nsrr_url("mesa")
 
 
 def test_get_nsrr_url_env_nsrr_token_set(monkeypatch):
-    """Tests the get_nsrr_url method with nsrr_token set as environment variable."""
-    # simulate set environment variable
+    """Test the _get_nsrr_url method with token set via an environment variable."""
     monkeypatch.setenv("nsrr_token", "token")
     nsrr_url = _get_nsrr_url("mesa")
     assert nsrr_url == "https://sleepdata.org/datasets/mesa/files/a/token/m/sleepecg/"
@@ -49,8 +42,7 @@ def _patch_get_config_value_return(key):
 
 
 def test_get_nsrr_url_config_nsrr_token_set(monkeypatch):
-    """Tests the get_nsrr_url method with nsrr_token set in the config file."""
-    # simulate blank environment variable
+    """Test the _get_nsrr_url method with token set in the config file."""
     monkeypatch.delenv("nsrr_token", raising=False)
     monkeypatch.setattr("sleepecg.get_config_value", _patch_get_config_value_return)
     nsrr_url = _get_nsrr_url("mesa")
@@ -59,8 +51,7 @@ def test_get_nsrr_url_config_nsrr_token_set(monkeypatch):
 
 @patch("sleepecg.io.nsrr._nsrr_token", "token")
 def test_get_nsrr_url_function_nsrr_token_set(monkeypatch):
-    """Tests the get_nsrr_url method with nsrr_token set via the set_nsrr_token function."""
-    # simulate blank environment variable
+    """Test the _get_nsrr_url method with token set via the set_nsrr_token function."""
     monkeypatch.delenv("nsrr_token", raising=False)
     nsrr_url = _get_nsrr_url("mesa")
     assert nsrr_url == "https://sleepdata.org/datasets/mesa/files/a/token/m/sleepecg/"

--- a/tests/test_nsrr.py
+++ b/tests/test_nsrr.py
@@ -2,12 +2,15 @@
 #
 # License: BSD (3-clause)
 
+"""Tests for the handling of the nsrr data."""
+
 import pytest
 from unittest.mock import patch
 
 import sleepecg.io.nsrr
 import sleepecg.config
 from sleepecg.io.nsrr import _get_nsrr_url
+
 
 @pytest.fixture(autouse=True)
 def temp_test_config(tmp_path):
@@ -22,6 +25,7 @@ def temp_test_config(tmp_path):
     # cleanup
     sleepecg.config._USER_CONFIG_PATH = user_config_path_backup
 
+
 def test_get_nsrr_url_no_nsrr_token_set(monkeypatch):
     """Tests the get_nsrr_url method with no nsrr_token set."""
     # simulate blank environment variable
@@ -30,6 +34,7 @@ def test_get_nsrr_url_no_nsrr_token_set(monkeypatch):
     with pytest.raises(RuntimeError, match="NSRR token not set"):
         _get_nsrr_url("mesa")
 
+
 def test_get_nsrr_url_env_nsrr_token_set(monkeypatch):
     """Tests the get_nsrr_url method with nsrr_token set as environment variable."""
     # simulate set environment variable
@@ -37,20 +42,24 @@ def test_get_nsrr_url_env_nsrr_token_set(monkeypatch):
     nsrr_url = _get_nsrr_url("mesa")
     assert nsrr_url == "https://sleepdata.org/datasets/mesa/files/a/token/m/sleepecg/"
 
-def patch_get_config_value_return(key):
+
+def _patch_get_config_value_return(key):
     return "token"
 
+
 def test_get_nsrr_url_config_nsrr_token_set(monkeypatch):
+    """Tests the get_nsrr_url method with nsrr_token set in the config file."""
     # simulate blank environment variable
     monkeypatch.delenv("nsrr_token", raising=False)
-    monkeypatch.setattr("sleepecg.get_config_value", patch_get_config_value_return)
+    monkeypatch.setattr("sleepecg.get_config_value", _patch_get_config_value_return)
     nsrr_url = _get_nsrr_url("mesa")
     assert nsrr_url == "https://sleepdata.org/datasets/mesa/files/a/token/m/sleepecg/"
+
 
 @patch("sleepecg.io.nsrr._nsrr_token", "token")
-def test_get_nsrr_url_function_nsrr_token_set():
+def test_get_nsrr_url_function_nsrr_token_set(monkeypatch):
     """Tests the get_nsrr_url method with nsrr_token set via the set_nsrr_token function."""
+    # simulate blank environment variable
+    monkeypatch.delenv("nsrr_token", raising=False)
     nsrr_url = _get_nsrr_url("mesa")
     assert nsrr_url == "https://sleepdata.org/datasets/mesa/files/a/token/m/sleepecg/"
-
-

--- a/tests/test_nsrr.py
+++ b/tests/test_nsrr.py
@@ -4,11 +4,12 @@
 
 """Tests for the handling of the nsrr data."""
 
-import pytest
 from unittest.mock import patch
 
-import sleepecg.io.nsrr
+import pytest
+
 import sleepecg.config
+import sleepecg.io.nsrr
 from sleepecg.io.nsrr import _get_nsrr_url
 
 

--- a/tests/test_nsrr.py
+++ b/tests/test_nsrr.py
@@ -24,7 +24,7 @@ def temp_test_config(tmp_path):
 
 def test_get_nsrr_url_no_nsrr_token_set(monkeypatch):
     """Test the _get_nsrr_url method with no token set."""
-    monkeypatch.delenv("nsrr_token", raising=False)
+    monkeypatch.delenv("NSRR_TOKEN", raising=False)
 
     with pytest.raises(RuntimeError, match="NSRR token not set"):
         _get_nsrr_url("mesa")
@@ -32,19 +32,15 @@ def test_get_nsrr_url_no_nsrr_token_set(monkeypatch):
 
 def test_get_nsrr_url_env_nsrr_token_set(monkeypatch):
     """Test the _get_nsrr_url method with token set via an environment variable."""
-    monkeypatch.setenv("nsrr_token", "token")
+    monkeypatch.setenv("NSRR_TOKEN", "token")
     nsrr_url = _get_nsrr_url("mesa")
     assert nsrr_url == "https://sleepdata.org/datasets/mesa/files/a/token/m/sleepecg/"
 
 
-def _patch_get_config_value_return(key):
-    return "token"
-
-
 def test_get_nsrr_url_config_nsrr_token_set(monkeypatch):
     """Test the _get_nsrr_url method with token set in the config file."""
-    monkeypatch.delenv("nsrr_token", raising=False)
-    monkeypatch.setattr("sleepecg.get_config_value", _patch_get_config_value_return)
+    monkeypatch.delenv("NSRR_TOKEN", raising=False)
+    sleepecg.config.set_config(nsrr_token="token")
     nsrr_url = _get_nsrr_url("mesa")
     assert nsrr_url == "https://sleepdata.org/datasets/mesa/files/a/token/m/sleepecg/"
 
@@ -52,6 +48,6 @@ def test_get_nsrr_url_config_nsrr_token_set(monkeypatch):
 @patch("sleepecg.io.nsrr._nsrr_token", "token")
 def test_get_nsrr_url_function_nsrr_token_set(monkeypatch):
     """Test the _get_nsrr_url method with token set via the set_nsrr_token function."""
-    monkeypatch.delenv("nsrr_token", raising=False)
+    monkeypatch.delenv("NSRR_TOKEN", raising=False)
     nsrr_url = _get_nsrr_url("mesa")
     assert nsrr_url == "https://sleepdata.org/datasets/mesa/files/a/token/m/sleepecg/"

--- a/tests/test_nsrr.py
+++ b/tests/test_nsrr.py
@@ -1,0 +1,56 @@
+# © SleepECG developers
+#
+# License: BSD (3-clause)
+
+import pytest
+from unittest.mock import patch
+
+import sleepecg.io.nsrr
+import sleepecg.config
+from sleepecg.io.nsrr import _get_nsrr_url
+
+@pytest.fixture(autouse=True)
+def temp_test_config(tmp_path):
+    """Create, use and delete a temporary user config file for testing."""
+    # setup
+    user_config_path_backup = sleepecg.config._USER_CONFIG_PATH
+    sleepecg.config._USER_CONFIG_PATH = tmp_path / "testconfig.yml"
+
+    # execute test
+    yield
+
+    # cleanup
+    sleepecg.config._USER_CONFIG_PATH = user_config_path_backup
+
+def test_get_nsrr_url_no_nsrr_token_set(monkeypatch):
+    """Tests the get_nsrr_url method with no nsrr_token set."""
+    # simulate blank environment variable
+    monkeypatch.delenv("nsrr_url", raising=False)
+
+    with pytest.raises(RuntimeError, match="NSRR token not set"):
+        _get_nsrr_url("mesa")
+
+def test_get_nsrr_url_env_nsrr_token_set(monkeypatch):
+    """Tests the get_nsrr_url method with nsrr_token set as environment variable."""
+    # simulate set environment variable
+    monkeypatch.setenv("nsrr_token", "token")
+    nsrr_url = _get_nsrr_url("mesa")
+    assert nsrr_url == "https://sleepdata.org/datasets/mesa/files/a/token/m/sleepecg/"
+
+def patch_get_config_value_return(key):
+    return "token"
+
+def test_get_nsrr_url_config_nsrr_token_set(monkeypatch):
+    # simulate blank environment variable
+    monkeypatch.delenv("nsrr_token", raising=False)
+    monkeypatch.setattr("sleepecg.get_config_value", patch_get_config_value_return)
+    nsrr_url = _get_nsrr_url("mesa")
+    assert nsrr_url == "https://sleepdata.org/datasets/mesa/files/a/token/m/sleepecg/"
+
+@patch("sleepecg.io.nsrr._nsrr_token", "token")
+def test_get_nsrr_url_function_nsrr_token_set():
+    """Tests the get_nsrr_url method with nsrr_token set via the set_nsrr_token function."""
+    nsrr_url = _get_nsrr_url("mesa")
+    assert nsrr_url == "https://sleepdata.org/datasets/mesa/files/a/token/m/sleepecg/"
+
+


### PR DESCRIPTION
Added support for storing the nsrr_token in an environment variable or the config file of sleepecg. Since the nsrr_token can be set in multiple ways, the hierarchy for which nsrr_token is used is set as such:
1. using the nsrr_token set via the set_nsrr_token function defined in nsrr.py
2. using the nsrr_token set in an environment variable
3. using the nsrr_token set in the config file

Currently, sleepecg provides no functionality to set the nsrr_token as an environment variable or in the config file. Instead, these actions have to be performed by hand.

In addtion, the test_nsrr.py file was added introducing four test cases. Three cases cover the setting of the nsrr_token via methods 1-3 while the fourth test case covers an unset nsrr_token.