### PR TITLE
MAINT: Trivial CI bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     needs: style
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-14]
+        os: [ubuntu-22.04, windows-2022, macos-15]
     name: Build wheels (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     needs: style
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-14]
+        os: [ubuntu-22.04, windows-2022, macos-15]
     name: Run tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Workflows require approval until a PR has been merged (unless you tweak this setting), so get a tiny PR in first before putting in the real work and iteration in https://github.com/cbrnr/sleepecg/pull/251, otherwise the approval process will be a limiting factor