### PR TITLE
Remove dynamic version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,18 +110,17 @@ pytest -m "not c_extension"
 
 ## Releases
 
-Follow these steps to release a new version of SleepECG:
-- In `src/sleepecg/__init__.py` remove the `-dev` suffix in `__version__`.
-    - In case of a patch release, modify the version number accordingly.
-- In `CHANGELOG.md`, update `## [UNRELEASED] - YYYY-MM-DD` to contain the version number and current date.
-- Commit these changes as `Prepare vX.Y.Z release` and push.
-- [Create a new release](https://github.com/cbrnr/sleepecg/releases/new) on GitHub.
-    - Create a new tag where the target version is prefixed with a `v`, e.g. `v0.4.0`.
-    - Use the tag as the release title.
-    - Mention the most important changes in the release description and include a link to the changelog.
-- This triggers the [`release.yml`](https://github.com/cbrnr/sleepecg/blob/main/.github/workflows/release.yml) workflow, which builds the wheels and publishes the package on [PyPI](https://pypi.org/project/sleepecg).
+Follow these steps to make a new [PyPI](https://pypi.org/project/sleepecg/) release (requires write permissions for GitHub and PyPI project sites):
+
+- Remove the `.dev0` suffix from the `version` field in `pyproject.toml` (and/or adapt the version to be released if necessary)
+- Update the section in `CHANGELOG.md` corresponding to the new release with the version and current date
+- Commit these changes and push
+- Create a new release on GitHub and use the version as the tag name (make sure to prepend the version with a `v`, e.g. `v0.7.0`)
+- A GitHub Action takes care of building and uploading wheels to PyPI
 
 This concludes the new release. Now prepare the source for the next planned release as follows:
-- Update `__version__` in `src/sleepecg/__init__.py` to the next planned version and append `-dev`.
-- Start a new section at the top of `CHANGELOG.md` titled `## [UNRELEASED] - YYYY-MM-DD`.
-- Commit these changes as `Prepare vX.Y.Z-dev` and push.
+
+- Update the `version` field to the next planned release and append `.dev0`
+- Start a new section at the top of `CHANGELOG.md` titled `## [UNRELEASED] - YYYY-MM-DD`
+
+Don't forget to push these changes!

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,3 @@ ignore = ["D105"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
-
-[tool.setuptools.dynamic]
-version = {attr = "sleepecg.__version__"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sleepecg"
+version = "0.6.0.dev0"
 description = "A package for sleep stage classification using ECG data"
 license = {text = "BSD 3-Clause"}
 authors = [
@@ -33,7 +34,6 @@ dependencies = [
     "scipy >= 1.13.0",
     "tqdm >= 4.66.0",
 ]
-dynamic = ["version"]
 
 [project.optional-dependencies]
 cibw = [  # cibuildwheel uses this for running the test suite

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,12 +44,10 @@ cibw = [  # cibuildwheel uses this for running the test suite
     "numba >= 0.61.0; platform_machine != 'aarch64'",
     "wfdb >= 4.2.0",
 ]
-
 docs = [  # RTD uses this when building the documentation
     "mkdocs-material >= 9.5.0",
     "mkdocstrings-python >= 1.11.1",
 ]
-
 full = [  # complete package functionality
     "edfio >= 0.4.4",
     "joblib >= 1.4.2",

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ from wheel.bdist_wheel import bdist_wheel
 # needs to change to 0x030B0000, and the cibuildwheel `build` selector needs to change
 # in pyproject.toml.
 
+
 class bdist_wheel_abi3(bdist_wheel):
     def get_tag(self) -> tuple:
         python, abi, plat = super().get_tag()

--- a/src/sleepecg/__init__.py
+++ b/src/sleepecg/__init__.py
@@ -1,5 +1,7 @@
 """A package for sleep stage classification using ECG data."""
 
+from importlib.metadata import PackageNotFoundError, version
+
 from sleepecg.classification import (
     SleepClassifier,
     evaluate,
@@ -17,4 +19,7 @@ from sleepecg.io import *  # noqa: F403
 from sleepecg.plot import plot_ecg, plot_hypnogram
 from sleepecg.utils import get_toy_ecg
 
-__version__ = "0.6.0-dev"
+try:
+    __version__ = version("sleepecg")
+except PackageNotFoundError:
+    __version__ = "unknown"


### PR DESCRIPTION
Instead of using a dynamic version, it is easier to put the actual version in `pyproject.toml` and then use `importlib.metadata.version()` to access it in SleepECG.