### PR TITLE
Build arm64 and x86_64 wheels on macos-15

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -31,7 +31,7 @@ jobs:
     name: Build wheel (${{ matrix.os }})
     strategy:
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2025, macos-15, macos-13]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2025, macos-15]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,9 @@ archs = "native"
 manylinux-x86_64-image = "manylinux_2_28"
 manylinux-aarch64-image = "manylinux_2_28"
 
+[tool.cibuildwheel.macos]
+archs = ["arm64", "x86_64"]
+
 [tool.cibuildwheel.windows]
 before-build = "pip install delvewheel"
 repair-wheel-command = [


### PR DESCRIPTION
Seems like this should be possible now.