### PR TITLE
Remove wheel from build-system.requires

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm", "numpy>=2"]
+requires = ["setuptools>=77.0.3", "setuptools-scm", "numpy>=2"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm", "wheel", "numpy>=2"]
+requires = ["setuptools", "setuptools-scm", "numpy>=2"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Frontend build tools that support PEP 517 install `wheel` automatically if needed.

Also require a recent setuptools for PEP 639 support.