### PR TITLE
Keep configuration lean: remove `license-files`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ name = "sleepecg"
 version = "0.6.0.dev0"
 description = "A package for sleep stage classification using ECG data"
 license = "BSD-3-Clause"
-license-files = ["LICENSE"]
 authors = [
     {name = "Florian Hofer", email = "hofaflo@gmail.com"},
     {name = "Clemens Brunner", email = "clemens.brunner@gmail.com"},


### PR DESCRIPTION
Most build backends will pick up all `LICEN[CS]E*` files.

That's of course true of setuptools:
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-files