### PR TITLE
docs(actigraphy): document external activity counts

### DIFF
--- a/docs/feature_extraction.md
+++ b/docs/feature_extraction.md
@@ -78,6 +78,46 @@ Group identifier: `metadata`
 
 Group identifier: `actigraphy`
 
-| Feature           | Description                                                                                            |
-|-------------------|--------------------------------------------------------------------------------------------------------|
-| `activity_counts` | Philips Actiwatch proprietary metric to quantify amount of patient movement measured via accelerometry |
+| Feature           | Description                                      |
+|-------------------|--------------------------------------------------|
+| `activity_counts` | Activity-count value for each feature-extraction epoch |
+
+[`read_mesa()`][sleepecg.read_mesa] can load activity counts calculated by Philips
+Actiware. For other datasets, externally calculated counts can be passed directly to
+[`SleepRecord`][sleepecg.SleepRecord]:
+
+```python
+import numpy as np
+from agcounts.extract import get_counts
+
+from sleepecg import SleepRecord, extract_features
+
+# raw_xyz has shape (n_samples, 3)
+axis_counts = get_counts(raw_xyz, freq=sampling_frequency, epoch=30)
+activity_counts = np.linalg.norm(axis_counts, axis=1)
+
+record = SleepRecord(
+    sleep_stages=sleep_stages,
+    sleep_stage_duration=30,
+    activity_counts=activity_counts,
+)
+features, stages, feature_ids = extract_features(
+    [record],
+    feature_selection=["actigraphy"],
+)
+```
+
+[`agcounts`](https://github.com/actigraph/agcounts) is an external package and is not
+installed with SleepECG.
+
+!!! warning
+
+    Activity counts are specific to the device and calculation method. For example,
+    ActiGraph counts calculated by `agcounts` are not equivalent to the proprietary Philips
+    Actiwatch values provided with MESA. Use the same method for training and prediction,
+    and make sure that the count epoch matches the `sleep_stage_duration` passed to
+    `extract_features()`.
+
+The classifiers bundled with SleepECG do not use actigraphy. Using activity counts for
+staging therefore requires a classifier trained with `activity_counts` in its feature
+selection.

--- a/src/sleepecg/feature_extraction.py
+++ b/src/sleepecg/feature_extraction.py
@@ -659,8 +659,21 @@ def _extract_features_single(
         elif feature_group == "metadata":
             X.append(_metadata_features(record, num_stages))
         elif feature_group == "actigraphy":
-            if record.activity_counts is not None:
-                X.append(record.activity_counts.reshape(-1, 1))
+            if record.activity_counts is None:
+                raise ValueError(
+                    f"Cannot extract actigraphy features for {record.id} without "
+                    "activity_counts."
+                )
+            if record.activity_counts.ndim != 1:
+                raise ValueError(
+                    f"activity_counts for {record.id} must be a one-dimensional array."
+                )
+            if len(record.activity_counts) != num_stages:
+                raise ValueError(
+                    f"activity_counts for {record.id} contains "
+                    f"{len(record.activity_counts)} values, but {num_stages} are required."
+                )
+            X.append(record.activity_counts.reshape(-1, 1))
     features = np.hstack(X)[:, col_indices]
 
     if record.sleep_stages is None or sleep_stage_duration == record.sleep_stage_duration:

--- a/src/sleepecg/io/sleep_readers.py
+++ b/src/sleepecg/io/sleep_readers.py
@@ -88,7 +88,9 @@ class SleepRecord:
     subject_data : SubjectData, optional
         Dataclass containing subject data (such as gender or age), by default `None`.
     activity_counts: np.ndarray, optional
-        Activity counts according to Actiwatch actigraphy, by default `None`.
+        One activity-count value per feature-extraction epoch, by default `None`. Activity
+        counts depend on the device and calculation method, so values produced by
+        different methods are not necessarily comparable.
     """
 
     sleep_stages: np.ndarray | None = None

--- a/tests/test_feature_extraction.py
+++ b/tests/test_feature_extraction.py
@@ -14,6 +14,7 @@ from sleepecg.feature_extraction import (
     _hrv_frequencydomain_features,
     _hrv_timedomain_features,
     _metadata_features,
+    extract_features,
 )
 from sleepecg.io.sleep_readers import SleepRecord, SubjectData
 
@@ -81,3 +82,44 @@ def test_metadata_features(metadata, feature_vec):
     X = _metadata_features(rec, num_stages)
     assert X.shape == (num_stages, 4)
     assert np.allclose(X, np.array(feature_vec), equal_nan=True)
+
+
+def test_actigraphy_features():
+    """Extract externally calculated activity counts."""
+    activity_counts = np.array([10.0, 20.0, 30.0, 40.0])
+    record = SleepRecord(
+        id="test",
+        sleep_stages=np.array([5, 2, 2, 4]),
+        sleep_stage_duration=30,
+        activity_counts=activity_counts,
+    )
+
+    features, stages, feature_ids = extract_features(
+        [record], feature_selection=["actigraphy"]
+    )
+
+    assert feature_ids == ["activity_counts"]
+    assert features[0].shape == (4, 1)
+    assert np.array_equal(features[0][:, 0], activity_counts)
+    assert np.array_equal(stages[0], record.sleep_stages)
+
+
+@pytest.mark.parametrize(
+    ("activity_counts", "message"),
+    [
+        (None, "without activity_counts"),
+        (np.ones((4, 1)), "must be a one-dimensional array"),
+        (np.ones(3), "contains 3 values, but 4 are required"),
+    ],
+)
+def test_actigraphy_features_invalid(activity_counts, message):
+    """Reject missing or misaligned activity counts."""
+    record = SleepRecord(
+        id="test",
+        sleep_stages=np.array([5, 2, 2, 4]),
+        sleep_stage_duration=30,
+        activity_counts=activity_counts,
+    )
+
+    with pytest.raises(ValueError, match=message):
+        extract_features([record], feature_selection=["actigraphy"])


### PR DESCRIPTION
## Why

`SleepRecord` already accepts externally calculated activity counts, but the workflow for non-MESA data was not documented. Invalid or misaligned counts could also reach feature extraction without a clear error.

## What Changed

- document an external `raw X/Y/Z -> agcounts -> SleepRecord` workflow
- explain that activity-count methods are device-specific and should remain consistent between training and prediction
- note that the bundled classifiers do not currently use actigraphy
- validate that `activity_counts` is one-dimensional and aligned with the feature-extraction epochs
- add tests for valid, missing, multidimensional, and misaligned counts

## Verification

The targeted tests confirm that valid external counts pass through unchanged, while missing, multidimensional, and length-mismatched inputs raise clear errors.

Refs #267.
