### PR TITLE
Fix repeated searchback scans on unusable ECG segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Remove support for macOS on Intel architecture (x86_64) ([#301](https://github.com/cbrnr/sleepecg/pull/301) by [Clemens Brunner](https://github.com/cbrnr))
 
 ### Fixed
-- Avoid repeated searchback scans when heartbeat detection encounters long unusable ECG intervals
+- Avoid repeated searchback scans when heartbeat detection encounters long unusable ECG intervals ([#319](https://github.com/cbrnr/sleepecg/pull/319) by [Daria Agafonova](https://github.com/viranovskaya))
 
 ## [0.5.9] - 2025-02-01
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Removed
 - Remove support for macOS on Intel architecture (x86_64) ([#301](https://github.com/cbrnr/sleepecg/pull/301) by [Clemens Brunner](https://github.com/cbrnr))
 
+### Fixed
+- Avoid repeated searchback scans when heartbeat detection encounters long unusable ECG intervals
+
 ## [0.5.9] - 2025-02-01
 ### Added
 - Add support to store NSRR token in environment variable or user config ([#243](https://github.com/cbrnr/sleepecg/pull/243) by [Simon Pusterhofer](https://github.com/simon-p-2000))

--- a/src/sleepecg/_heartbeat_detection.c
+++ b/src/sleepecg/_heartbeat_detection.c
@@ -248,6 +248,7 @@ static PyObject *_thresholding(PyObject *self,
     // initialize, so searchback before any peak has been detected works
     int peak_index = -REFRACTORY_SAMPLES + 1;
     int previous_peak_index = -REFRACTORY_SAMPLES + 1;
+    int searchback_start_index = previous_peak_index + REFRACTORY_SAMPLES;
 
     int index = 1;
     while (index < signal_len - 1)
@@ -298,7 +299,7 @@ static PyObject *_thresholding(PyObject *self,
                 char found_a_candidate = 0;
 
                 int searchback_divisor = 1 << i; // 2^i
-                int best_searchback_index = previous_peak_index + REFRACTORY_SAMPLES;
+                int best_searchback_index = searchback_start_index;
                 double best_candidate_amplitude = -1;
                 int searchback_index = best_searchback_index;
 
@@ -342,6 +343,14 @@ static PyObject *_thresholding(PyObject *self,
                     do_searchback = 0;
                     break;
                 }
+            }
+
+            // The thresholds do not change while searchback is active.
+            // If this pass found no candidate, the next pass only needs
+            // to inspect samples added since now.
+            if (!signal_peak_found)
+            {
+                searchback_start_index = index;
             }
         }
         else if (filtered_ecg[index] > filtered_ecg[index + 1])
@@ -510,6 +519,7 @@ static PyObject *_thresholding(PyObject *self,
 
             // previous peak index is required to calculate the RR interval
             previous_peak_index = peak_index;
+            searchback_start_index = peak_index + REFRACTORY_SAMPLES;
 
             // no peak can happen during the refractory period, so skip it
             index = peak_index + REFRACTORY_SAMPLES;

--- a/src/sleepecg/heartbeats.py
+++ b/src/sleepecg/heartbeats.py
@@ -394,6 +394,7 @@ def _thresholding_py(
     # initialize, so searchback before any peak has been detected works
     peak_index = -REFRACTORY_SAMPLES + 1
     previous_peak_index = -REFRACTORY_SAMPLES + 1
+    searchback_start_index = previous_peak_index + REFRACTORY_SAMPLES
 
     index = 1
     while index < signal_len - 1:
@@ -442,7 +443,7 @@ def _thresholding_py(
                 found_a_candidate = False
 
                 searchback_divisor = 1 << i  # 2^i
-                best_searchback_index = previous_peak_index + REFRACTORY_SAMPLES
+                best_searchback_index = searchback_start_index
                 best_candidate_amplitude = -1
                 searchback_index = best_searchback_index
 
@@ -488,6 +489,11 @@ def _thresholding_py(
                     # to avoid endless loops
                     do_searchback = False
                     break
+
+            # The thresholds do not change while searchback is active. If this pass found
+            # no candidate, the next pass only needs to inspect samples added since now.
+            if not signal_peak_found:
+                searchback_start_index = index
 
         elif filtered_ecg[index] > filtered_ecg[index + 1]:
             if filtered_ecg[index] > filtered_ecg[index - 1]:
@@ -615,6 +621,7 @@ def _thresholding_py(
 
             # previous peak index is required to calculate the RR interval
             previous_peak_index = peak_index
+            searchback_start_index = peak_index + REFRACTORY_SAMPLES
 
             # no peak can happen during the refractory period, so skip it
             index = peak_index + REFRACTORY_SAMPLES

--- a/tests/test_heartbeat_detection.py
+++ b/tests/test_heartbeat_detection.py
@@ -90,7 +90,7 @@ def test_unsuccessful_searchback_scans_incrementally():
             self.counter = getattr(source, "counter", [0])
 
         def __getitem__(self, key):
-            if isinstance(key, (int, np.integer)):
+            if isinstance(key, int | np.integer):
                 self.counter[0] += 1
             return super().__getitem__(key)
 

--- a/tests/test_heartbeat_detection.py
+++ b/tests/test_heartbeat_detection.py
@@ -76,6 +76,47 @@ def test_flat_data():
         detect_heartbeats([], fs)
 
 
+def test_unsuccessful_searchback_scans_incrementally():
+    """Do not rescan an unusable interval after a failed searchback."""
+    from sleepecg.heartbeats import _thresholding_py
+
+    class CountingArray(np.ndarray):
+        def __new__(cls, values, counter):
+            array = np.asarray(values).view(cls)
+            array.counter = counter
+            return array
+
+        def __array_finalize__(self, source):
+            self.counter = getattr(source, "counter", [0])
+
+        def __getitem__(self, key):
+            if isinstance(key, (int, np.integer)):
+                self.counter[0] += 1
+            return super().__getitem__(key)
+
+    reads = [0]
+    unusable = CountingArray(-np.ones(500), reads)
+    beat_mask = _thresholding_py(unusable, unusable, fs=100.0)
+
+    assert not beat_mask.any()
+    assert reads[0] < 50_000
+
+
+@pytest.mark.parametrize("backend", ["c", "numba", "python"])
+def test_large_initial_artifact_does_not_stall(backend):
+    """Finish detection when an initial artifact makes later peaks undetectable."""
+    if backend == "numba":
+        pytest.importorskip("numba")
+
+    rng = np.random.default_rng(42)
+    unusable_ecg = rng.normal(scale=1e-6, size=1_000)
+    unusable_ecg[50] = 1e6
+
+    beats = detect_heartbeats(unusable_ecg, fs=100.0, backend=backend)
+
+    np.testing.assert_array_equal(beats, [50])
+
+
 def test_squared_moving_integration_args():
     """Test squared moving window integration argument parsing."""
     from sleepecg._heartbeat_detection import _squared_moving_integration


### PR DESCRIPTION
Addresses the detector-stall part of #141.

The detector could appear to hang on a long noisy interval because every unsuccessful searchback started again after the previous detected peak. The same increasingly long interval was scanned up to 15 times at every new sample.

This change keeps track of the part of the interval that has already been checked. After an unsuccessful searchback, the next pass only checks newly added samples. The thresholds do not change while this branch is active, so rescanning the older part cannot produce a new candidate.

The cursor resets whenever a heartbeat is detected. The same logic is used by the Python, Numba and C implementations.

Checks:

- added a deterministic regression test for repeated searchback scans;
- added a noisy-signal test for all three backends;
- full test suite: 55 passed;
- Ruff and `git diff --check` passed;
- existing toy and seeded signals return unchanged heartbeat indices.

This fixes the computational stall. It does not add ECG quality classification or a mask for unusable intervals.