### PR TITLE
Add CAP Sleep Database reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [UNRELEASED] - YYYY-MM-DD
 ## Added
+- Add a reader for the CAP Sleep Database ([#35](https://github.com/cbrnr/sleepecg/issues/35) by [Daria Agafonova](https://github.com/viranovskaya))
 - Add support for activity counts feature ([#262](https://github.com/cbrnr/sleepecg/pull/262) by [Simon Pusterhofer](https://github.com/simon-p-2000))
 
 ### Removed

--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -5,6 +5,7 @@ See [Datasets](../datasets.md) for information about available datasets and inst
 ::: sleepecg.download_nsrr
 ::: sleepecg.download_physionet
 ::: sleepecg.export_ecg_record
+::: sleepecg.read_capslpdb
 ::: sleepecg.read_gudb
 ::: sleepecg.read_ltdb
 ::: sleepecg.read_mesa

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,5 +5,5 @@ This table lists the possible configuration settings and where they are used:
 
 | Key               | Default value               | Description | Used in |
 | ----------------- | --------------------------- | ----------- | ------- |
-| `data_dir`        | `'~/.sleepecg/datasets'`    | Default location for storing files downloaded by reader functions, including data downloaded for tests. | [`read_ltdb()`][sleepecg.read_ltdb], [`read_mitdb()`][sleepecg.read_mitdb], [`read_gudb()`][sleepecg.read_gudb], [`read_mesa()`][sleepecg.read_mesa], [`read_shhs()`][sleepecg.read_shhs], [`read_slpdb()`][sleepecg.read_slpdb] |
+| `data_dir`        | `'~/.sleepecg/datasets'`    | Default location for storing files downloaded by reader functions, including data downloaded for tests. | [`read_capslpdb()`][sleepecg.read_capslpdb], [`read_ltdb()`][sleepecg.read_ltdb], [`read_mitdb()`][sleepecg.read_mitdb], [`read_gudb()`][sleepecg.read_gudb], [`read_mesa()`][sleepecg.read_mesa], [`read_shhs()`][sleepecg.read_shhs], [`read_slpdb()`][sleepecg.read_slpdb] |
 | `classifiers_dir` | `'~/.sleepecg/classifiers'` | Default location for `SleepClassifier` objects. | [`list_classifiers()`][sleepecg.list_classifiers], [`load_classifier()`][sleepecg.load_classifier], [`save_classifier()`][sleepecg.save_classifier] |

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -5,9 +5,12 @@ SleepECG provides reader functions for various datasets. All required files will
 ## Sleep readers
 |Reader|Dataset name|Annotated records|Raw data size|Access|
 |-|-|-|-|-|
+|[`read_capslpdb()`][sleepecg.read_capslpdb]|[CAP Sleep Database](https://physionet.org/content/capslpdb/)|108 (107 with ECG)|40.1 GB|open|
 |[`read_mesa()`][sleepecg.read_mesa]|[Multi-Ethnic Study of Atherosclerosis](https://sleepdata.org/datasets/mesa/)|2056|385 GB|[request](https://sleepdata.org/data/requests/mesa/start)|
 |[`read_shhs()`][sleepecg.read_shhs]|[Sleep Heart Health Study](https://sleepdata.org/datasets/shhs/)|8444|356 GB|[request](https://sleepdata.org/data/requests/shhs/start)|
 |[`read_slpdb()`][sleepecg.read_slpdb]|[MIT-BIH Polysomnographic Database](https://physionet.org/content/slpdb)|18|632 MB|open|
+
+CAPSLPDB record `n16` is skipped with a warning because it does not contain an ECG channel.
 
 
 ## ECG readers

--- a/src/sleepecg/io/__init__.py
+++ b/src/sleepecg/io/__init__.py
@@ -4,6 +4,7 @@
 
 """Functions for downloading and reading datasets."""
 
+from sleepecg.io.capslpdb import read_capslpdb
 from sleepecg.io.ecg_readers import (
     ECGRecord,
     export_ecg_record,

--- a/src/sleepecg/io/capslpdb.py
+++ b/src/sleepecg/io/capslpdb.py
@@ -1,0 +1,334 @@
+# © SleepECG developers
+#
+# License: BSD (3-clause)
+
+"""Read records from the CAP Sleep Database."""
+
+from __future__ import annotations
+
+import csv
+import datetime
+import warnings
+from collections.abc import Iterator
+from itertools import pairwise
+from pathlib import Path
+from typing import TYPE_CHECKING, NamedTuple
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from edfio import Edf
+
+from sleepecg.config import get_config_value
+from sleepecg.heartbeats import detect_heartbeats
+from sleepecg.io.physionet import _list_physionet, download_physionet
+from sleepecg.io.sleep_readers import SleepRecord, SleepStage
+
+
+class _ParseCapslpdbResult(NamedTuple):
+    sleep_stages: np.ndarray
+    scoring_start_offset: int
+    malformed_rows: int
+
+
+_CAPSLPDB_STAGE_MAPPING = {
+    "SLEEP-S0": SleepStage.WAKE,
+    "SLEEP-S1": SleepStage.N1,
+    "SLEEP-S2": SleepStage.N2,
+    "SLEEP-S3": SleepStage.N3,
+    "SLEEP-S4": SleepStage.N3,
+    "SLEEP-REM": SleepStage.REM,
+    "SLEEP-MT": SleepStage.UNDEFINED,
+}
+
+
+def _clock_seconds(value: str) -> int:
+    parsed = datetime.datetime.strptime(value.replace(".", ":"), "%H:%M:%S")
+    return parsed.hour * 3600 + parsed.minute * 60 + parsed.second
+
+
+def _time_seconds(value: datetime.time) -> int:
+    return value.hour * 3600 + value.minute * 60 + value.second
+
+
+def _normalise_capslpdb_header(value: str) -> str:
+    return value.strip().replace("Duration [s]", "Duration[s]")
+
+
+def _read_capslpdb_stage_rows(
+    annotation_filepath: Path,
+) -> tuple[list[tuple[int, SleepStage]], int]:
+    lines = annotation_filepath.read_text(encoding="ascii").splitlines()
+    try:
+        header_index = next(
+            index
+            for index, line in enumerate(lines)
+            if line.split("\t", maxsplit=1)[0].strip() == "Sleep Stage"
+        )
+    except StopIteration as error:
+        raise RuntimeError(
+            f"Sleep-stage table header not found in {annotation_filepath}."
+        ) from error
+
+    reader = csv.DictReader(lines[header_index:], delimiter="\t")
+    if reader.fieldnames is None:
+        raise RuntimeError(
+            f"Sleep-stage table header not found in {annotation_filepath}."
+        )
+
+    rows: list[tuple[int, SleepStage]] = []
+    malformed_rows = 0
+    for raw_row in reader:
+        raw_row.pop(None, None)
+        row = {
+            _normalise_capslpdb_header(key): (value or "").strip()
+            for key, value in raw_row.items()
+        }
+        event = row.get("Event", "")
+        if not event.startswith("SLEEP-"):
+            if row.get("Sleep Stage", "") and not event:
+                malformed_rows += 1
+            continue
+
+        try:
+            clock = _clock_seconds(row.get("Time [hh:mm:ss]", ""))
+            duration = float(row.get("Duration[s]", ""))
+            stage = _CAPSLPDB_STAGE_MAPPING[event]
+        except (KeyError, ValueError):
+            malformed_rows += 1
+            continue
+
+        if duration != 30:
+            malformed_rows += 1
+            continue
+        rows.append((clock, stage))
+
+    if not rows:
+        raise RuntimeError(f"No valid sleep-stage rows found in {annotation_filepath}.")
+    return rows, malformed_rows
+
+
+def _parse_capslpdb_annotation(
+    annotation_filepath: Path,
+    recording_start_time: datetime.time,
+    recording_duration: float,
+) -> _ParseCapslpdbResult:
+    """Parse and align one CAPSLPDB annotation table to its EDF recording."""
+    rows, malformed_rows = _read_capslpdb_stage_rows(annotation_filepath)
+    recording_start = _time_seconds(recording_start_time)
+
+    first_offset = (rows[0][0] - recording_start + 12 * 3600) % (24 * 3600)
+    first_offset -= 12 * 3600
+
+    onsets = [first_offset]
+    for (previous_clock, _), (clock, _) in pairwise(rows):
+        onsets.append(onsets[-1] + (clock - previous_clock) % (24 * 3600))
+
+    aligned = [(onset, stage) for onset, (_, stage) in zip(onsets, rows) if onset >= 0]
+    if not aligned:
+        raise RuntimeError(
+            f"All sleep-stage rows precede the recording in {annotation_filepath}."
+        )
+
+    scoring_start_offset = aligned[0][0]
+    stages = [aligned[0][1]]
+    previous_onset, previous_stage = aligned[0]
+    for onset, stage in aligned[1:]:
+        difference = onset - previous_onset
+        if difference < 30 or difference % 30:
+            raise RuntimeError(
+                f"Sleep-stage grid changes by {difference} seconds in "
+                f"{annotation_filepath}."
+            )
+        stages.extend([previous_stage] * (difference // 30 - 1))
+        stages.append(stage)
+        previous_onset = onset
+        previous_stage = stage
+
+    complete_epochs = max(
+        int((recording_duration - scoring_start_offset) // 30),
+        0,
+    )
+    stages = stages[:complete_epochs]
+    if not stages:
+        raise RuntimeError(
+            f"No complete scored epochs overlap the recording in {annotation_filepath}."
+        )
+
+    if malformed_rows:
+        warnings.warn(
+            f"Skipped {malformed_rows} malformed sleep-stage row(s) in "
+            f"{annotation_filepath}.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
+    return _ParseCapslpdbResult(
+        sleep_stages=np.asarray(stages, dtype=np.int8),
+        scoring_start_offset=scoring_start_offset,
+        malformed_rows=malformed_rows,
+    )
+
+
+def _get_capslpdb_ecg(edf: Edf) -> tuple[np.ndarray, float] | None:
+    signals = {signal.label.casefold(): signal for signal in edf.signals}
+    for label in ("ecg1-ecg2", "ecg", "ekg"):
+        if label in signals:
+            signal = signals[label]
+            return np.asarray(signal.data), float(signal.sampling_frequency)
+
+    if "ecg1" not in signals or "ecg2" not in signals:
+        return None
+    ecg1 = signals["ecg1"]
+    ecg2 = signals["ecg2"]
+    if ecg1.sampling_frequency != ecg2.sampling_frequency:
+        raise RuntimeError("ECG1 and ECG2 have different sampling frequencies.")
+    return (
+        np.asarray(ecg1.data) - np.asarray(ecg2.data),
+        float(ecg1.sampling_frequency),
+    )
+
+
+def _shift_time(value: datetime.time, seconds: int) -> datetime.time:
+    start = datetime.datetime.combine(datetime.date.today(), value)
+    return (start + datetime.timedelta(seconds=seconds)).time()
+
+
+def read_capslpdb(
+    records_pattern: str = "*",
+    heartbeats_source: str = "ecg",
+    offline: bool = False,
+    keep_edfs: bool = False,
+    data_dir: str | Path | None = None,
+) -> Iterator[SleepRecord]:
+    """
+    Lazily read records from [CAPSLPDB](https://physionet.org/content/capslpdb/).
+
+    Each record consists of an EDF file containing polysomnography signals and a text
+    file containing sleep-stage annotations. Sleep stages are aligned to complete
+    30-second epochs covered by the EDF recording. Missing internal annotation rows are
+    filled with the preceding stage, following the reference CAPSLPDB reader.
+
+    Parameters
+    ----------
+    records_pattern : str, optional
+        Glob-like pattern to select record IDs, by default `'*'`.
+    heartbeats_source : {'cached', 'ecg'}, optional
+        If `'ecg'` (default), detect heartbeat times from the ECG and cache them. If
+        `'cached'`, read previously cached heartbeat times.
+    offline : bool, optional
+        If `True`, search for local files only instead of downloading from PhysioNet, by
+        default `False`.
+    keep_edfs : bool, optional
+        If `False`, remove EDF files downloaded for heartbeat detection after processing,
+        by default `False`.
+    data_dir : str | pathlib.Path, optional
+        Directory where all datasets are stored. If `None` (default), the value will be
+        taken from the configuration.
+
+    Yields
+    ------
+    SleepRecord
+        Each element in the generator is of type `SleepRecord`.
+    """
+    from edfio import read_edf
+
+    db_slug = "capslpdb"
+    if heartbeats_source not in {"cached", "ecg"}:
+        raise ValueError(
+            f"Invalid value for parameter `heartbeats_source`: {heartbeats_source}, "
+            "possible options: {'cached', 'ecg'}"
+        )
+    if data_dir is None:
+        data_dir = get_config_value("data_dir")
+
+    data_dir = Path(data_dir).expanduser()
+    db_dir = data_dir / db_slug
+    heartbeats_dir = db_dir / "preprocessed/heartbeats"
+    heartbeats_dir.mkdir(parents=True, exist_ok=True)
+
+    requested_records = [
+        Path(filename).stem
+        for filename in _list_physionet(
+            data_dir=data_dir,
+            db_slug=db_slug,
+            pattern=f"{records_pattern}.edf",
+        )
+    ]
+    if "n16" in requested_records:
+        warnings.warn(
+            "Skipping n16 because its EDF does not contain an ECG channel.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        requested_records.remove("n16")
+    edf_was_available = {
+        record_id: (db_dir / f"{record_id}.edf").is_file()
+        for record_id in requested_records
+    }
+    if not offline:
+        download_physionet(
+            db_slug=db_slug,
+            requested_records=requested_records,
+            extensions=[".edf", ".txt"],
+            data_dir=data_dir,
+        )
+
+    for record_id in requested_records:
+        edf_filepath = db_dir / f"{record_id}.edf"
+        annotation_filepath = db_dir / f"{record_id}.txt"
+        heartbeats_filepath = heartbeats_dir / f"{record_id}.npy"
+
+        if heartbeats_source == "cached" and not heartbeats_filepath.is_file():
+            print(f"Skipping {record_id} due to missing cached heartbeats.")
+            continue
+
+        edf = read_edf(edf_filepath, lazy_load_data=True)
+        parsed = _parse_capslpdb_annotation(
+            annotation_filepath,
+            recording_start_time=edf.starttime,
+            recording_duration=edf.duration,
+        )
+        scored_duration = len(parsed.sleep_stages) * 30
+
+        if heartbeats_source == "cached":
+            heartbeat_times = np.load(heartbeats_filepath)
+        else:
+            ecg_data = _get_capslpdb_ecg(edf)
+            if ecg_data is None:
+                warnings.warn(
+                    f"Skipping {record_id} because its EDF does not contain a supported "
+                    "ECG channel.",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+                if not edf_was_available[record_id] and not keep_edfs:
+                    edf_filepath.unlink()
+                continue
+            ecg, sampling_frequency = ecg_data
+            heartbeat_times = (
+                detect_heartbeats(ecg, sampling_frequency) / sampling_frequency
+                - parsed.scoring_start_offset
+            )
+            heartbeat_times = heartbeat_times[
+                (heartbeat_times >= 0) & (heartbeat_times < scored_duration)
+            ]
+            np.save(heartbeats_filepath, heartbeat_times)
+
+        heartbeat_times = heartbeat_times[
+            (heartbeat_times >= 0) & (heartbeat_times < scored_duration)
+        ]
+
+        if not edf_was_available[record_id] and not keep_edfs:
+            edf_filepath.unlink()
+
+        yield SleepRecord(
+            sleep_stages=parsed.sleep_stages,
+            sleep_stage_duration=30,
+            id=record_id,
+            recording_start_time=_shift_time(
+                edf.starttime,
+                parsed.scoring_start_offset,
+            ),
+            heartbeat_times=heartbeat_times,
+        )

--- a/src/sleepecg/io/capslpdb.py
+++ b/src/sleepecg/io/capslpdb.py
@@ -359,9 +359,10 @@ def read_capslpdb(
             if not edf_was_available[record_id] and not keep_edfs:
                 edf_filepath.unlink()
 
-        heartbeat_times = heartbeat_times[
-            (heartbeat_times >= 0) & (heartbeat_times < scored_duration)
-        ]
+        else:
+            heartbeat_times = heartbeat_times[
+                (heartbeat_times >= 0) & (heartbeat_times < scored_duration)
+            ]
 
         yield SleepRecord(
             sleep_stages=parsed.sleep_stages,

--- a/src/sleepecg/io/capslpdb.py
+++ b/src/sleepecg/io/capslpdb.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import csv
 import datetime
+import json
 import warnings
 from collections.abc import Iterator
 from itertools import pairwise
@@ -194,6 +195,26 @@ def _shift_time(value: datetime.time, seconds: int) -> datetime.time:
     return (start + datetime.timedelta(seconds=seconds)).time()
 
 
+def _save_recording_metadata(
+    filepath: Path,
+    recording_start_time: datetime.time,
+    recording_duration: float,
+) -> None:
+    metadata = {
+        "recording_start_time": recording_start_time.isoformat(),
+        "recording_duration": recording_duration,
+    }
+    filepath.write_text(json.dumps(metadata), encoding="utf-8")
+
+
+def _load_recording_metadata(filepath: Path) -> tuple[datetime.time, float]:
+    metadata = json.loads(filepath.read_text(encoding="utf-8"))
+    return (
+        datetime.time.fromisoformat(metadata["recording_start_time"]),
+        float(metadata["recording_duration"]),
+    )
+
+
 def read_capslpdb(
     records_pattern: str = "*",
     heartbeats_source: str = "ecg",
@@ -231,8 +252,6 @@ def read_capslpdb(
     SleepRecord
         Each element in the generator is of type `SleepRecord`.
     """
-    from edfio import read_edf
-
     db_slug = "capslpdb"
     if heartbeats_source not in {"cached", "ecg"}:
         raise ValueError(
@@ -262,38 +281,56 @@ def read_capslpdb(
             stacklevel=2,
         )
         requested_records.remove("n16")
-    edf_was_available = {
-        record_id: (db_dir / f"{record_id}.edf").is_file()
-        for record_id in requested_records
-    }
     if not offline:
         download_physionet(
             db_slug=db_slug,
             requested_records=requested_records,
-            extensions=[".edf", ".txt"],
+            extensions=[".txt"],
             data_dir=data_dir,
         )
+    edf_was_available = {}
+    if heartbeats_source == "ecg":
+        edf_was_available = {
+            record_id: (db_dir / f"{record_id}.edf").is_file()
+            for record_id in requested_records
+        }
+        if not offline:
+            download_physionet(
+                db_slug=db_slug,
+                requested_records=requested_records,
+                extensions=[".edf"],
+                data_dir=data_dir,
+            )
 
     for record_id in requested_records:
         edf_filepath = db_dir / f"{record_id}.edf"
         annotation_filepath = db_dir / f"{record_id}.txt"
         heartbeats_filepath = heartbeats_dir / f"{record_id}.npy"
+        metadata_filepath = heartbeats_dir / f"{record_id}.json"
 
-        if heartbeats_source == "cached" and not heartbeats_filepath.is_file():
-            print(f"Skipping {record_id} due to missing cached heartbeats.")
-            continue
+        if heartbeats_source == "cached":
+            if not heartbeats_filepath.is_file() or not metadata_filepath.is_file():
+                print(f"Skipping {record_id} due to incomplete cached data.")
+                continue
+            heartbeat_times = np.load(heartbeats_filepath)
+            recording_start_time, recording_duration = _load_recording_metadata(
+                metadata_filepath
+            )
+        else:
+            from edfio import read_edf
 
-        edf = read_edf(edf_filepath, lazy_load_data=True)
+            edf = read_edf(edf_filepath, lazy_load_data=True)
+            recording_start_time = edf.starttime
+            recording_duration = edf.duration
+
         parsed = _parse_capslpdb_annotation(
             annotation_filepath,
-            recording_start_time=edf.starttime,
-            recording_duration=edf.duration,
+            recording_start_time=recording_start_time,
+            recording_duration=recording_duration,
         )
         scored_duration = len(parsed.sleep_stages) * 30
 
-        if heartbeats_source == "cached":
-            heartbeat_times = np.load(heartbeats_filepath)
-        else:
+        if heartbeats_source == "ecg":
             ecg_data = _get_capslpdb_ecg(edf)
             if ecg_data is None:
                 warnings.warn(
@@ -314,20 +351,24 @@ def read_capslpdb(
                 (heartbeat_times >= 0) & (heartbeat_times < scored_duration)
             ]
             np.save(heartbeats_filepath, heartbeat_times)
+            _save_recording_metadata(
+                metadata_filepath,
+                recording_start_time,
+                recording_duration,
+            )
+            if not edf_was_available[record_id] and not keep_edfs:
+                edf_filepath.unlink()
 
         heartbeat_times = heartbeat_times[
             (heartbeat_times >= 0) & (heartbeat_times < scored_duration)
         ]
-
-        if not edf_was_available[record_id] and not keep_edfs:
-            edf_filepath.unlink()
 
         yield SleepRecord(
             sleep_stages=parsed.sleep_stages,
             sleep_stage_duration=30,
             id=record_id,
             recording_start_time=_shift_time(
-                edf.starttime,
+                recording_start_time,
                 parsed.scoring_start_offset,
             ),
             heartbeat_times=heartbeat_times,

--- a/tests/test_capslpdb.py
+++ b/tests/test_capslpdb.py
@@ -1,0 +1,279 @@
+# © SleepECG developers
+#
+# License: BSD (3-clause)
+
+"""Tests for the CAP Sleep Database reader."""
+
+from __future__ import annotations
+
+import datetime
+from pathlib import Path
+
+import numpy as np
+import pytest
+from edfio import Edf, EdfSignal
+
+from sleepecg import SleepStage, read_capslpdb
+from sleepecg.io.capslpdb import (
+    _get_capslpdb_ecg,
+    _parse_capslpdb_annotation,
+)
+
+
+def _write_annotation(
+    path: Path,
+    rows: list[tuple[str, str, str, str]],
+    *,
+    duration_header: str = "Duration[s]",
+) -> None:
+    lines = [
+        "CAP Sleep Database test fixture",
+        f"Sleep Stage\tTime [hh:mm:ss]\tEvent\t{duration_header}\tLocation",
+    ]
+    lines.extend("\t".join((*row, "C3")) for row in rows)
+    path.write_text("\n".join(lines), encoding="ascii")
+
+
+def _write_edf(
+    path: Path,
+    labels: tuple[str, ...] = ("ECG",),
+    *,
+    duration: int = 120,
+    sampling_frequency: int = 100,
+) -> None:
+    signals = [
+        EdfSignal(
+            np.full(duration * sampling_frequency, index + 1.0),
+            sampling_frequency,
+            label=label,
+        )
+        for index, label in enumerate(labels)
+    ]
+    Edf(signals, starttime=datetime.time(22, 0)).write(path)
+
+
+def test_parse_capslpdb_annotation_maps_event_fills_gaps_and_clips(tmp_path):
+    """Map event labels, fill internal gaps and keep complete EDF epochs."""
+    annotation = tmp_path / "record.txt"
+    _write_annotation(
+        annotation,
+        [
+            ("W", "21:59:30", "SLEEP-S0", "30"),
+            ("1S3", "22:00:00", "SLEEP-S1", "30"),
+            ("S2", "22:01:00", "SLEEP-S2", "30"),
+            ("S3", "22:01:30", "SLEEP-S3", "30"),
+            ("S4", "22:02:00", "SLEEP-S4", "30"),
+            ("R", "22:02:30", "SLEEP-REM", "30"),
+        ],
+    )
+
+    parsed = _parse_capslpdb_annotation(
+        annotation,
+        recording_start_time=datetime.time(22, 0),
+        recording_duration=150,
+    )
+
+    assert parsed.sleep_stages.tolist() == [
+        SleepStage.N1,
+        SleepStage.N1,
+        SleepStage.N2,
+        SleepStage.N3,
+        SleepStage.N3,
+    ]
+    assert parsed.scoring_start_offset == 0
+    assert parsed.malformed_rows == 0
+
+
+def test_parse_capslpdb_annotation_accepts_header_and_time_variants(tmp_path):
+    """Accept the duration header and dotted times used by individual records."""
+    annotation = tmp_path / "record.txt"
+    _write_annotation(
+        annotation,
+        [
+            ("W", "22.00.30", "SLEEP-S0", "30"),
+            ("R", "22.01.00", "SLEEP-REM", "30"),
+            ("MT", "22.01.30", "SLEEP-MT", "30"),
+        ],
+        duration_header="Duration [s]",
+    )
+
+    parsed = _parse_capslpdb_annotation(
+        annotation,
+        recording_start_time=datetime.time(22, 0),
+        recording_duration=120,
+    )
+
+    assert parsed.sleep_stages.tolist() == [
+        SleepStage.WAKE,
+        SleepStage.REM,
+        SleepStage.UNDEFINED,
+    ]
+    assert parsed.scoring_start_offset == 30
+
+
+def test_parse_capslpdb_annotation_aligns_across_midnight(tmp_path):
+    """Drop a pre-recording row and keep the 30-second grid across midnight."""
+    annotation = tmp_path / "record.txt"
+    _write_annotation(
+        annotation,
+        [
+            ("W", "23:59:00", "SLEEP-S0", "30"),
+            ("S1", "23:59:30", "SLEEP-S1", "30"),
+            ("S2", "00:00:00", "SLEEP-S2", "30"),
+        ],
+    )
+
+    parsed = _parse_capslpdb_annotation(
+        annotation,
+        recording_start_time=datetime.time(23, 59, 30),
+        recording_duration=60,
+    )
+
+    assert parsed.sleep_stages.tolist() == [SleepStage.N1, SleepStage.N2]
+    assert parsed.scoring_start_offset == 0
+
+
+def test_parse_capslpdb_annotation_warns_about_malformed_stage_row(tmp_path):
+    """Skip a truncated stage row with one record-level warning."""
+    annotation = tmp_path / "record.txt"
+    _write_annotation(
+        annotation,
+        [
+            ("W", "22:00:00", "SLEEP-S0", "30"),
+            ("S1", "22:00:30", "", ""),
+        ],
+    )
+
+    with pytest.warns(RuntimeWarning, match="Skipped 1 malformed"):
+        parsed = _parse_capslpdb_annotation(
+            annotation,
+            recording_start_time=datetime.time(22, 0),
+            recording_duration=60,
+        )
+
+    assert parsed.sleep_stages.tolist() == [SleepStage.WAKE]
+    assert parsed.malformed_rows == 1
+
+
+def test_parse_capslpdb_annotation_rejects_irregular_grid(tmp_path):
+    """Reject stage rows that cannot be placed on one 30-second grid."""
+    annotation = tmp_path / "record.txt"
+    _write_annotation(
+        annotation,
+        [
+            ("W", "22:00:00", "SLEEP-S0", "30"),
+            ("S1", "22:00:45", "SLEEP-S1", "30"),
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match="grid changes by 45 seconds"):
+        _parse_capslpdb_annotation(
+            annotation,
+            recording_start_time=datetime.time(22, 0),
+            recording_duration=90,
+        )
+
+
+def test_get_capslpdb_ecg_uses_bipolar_signal():
+    """Derive a bipolar ECG when the two source channels are separate."""
+    edf = Edf(
+        [
+            EdfSignal(np.full(100, 3.0), 100, label="ECG1"),
+            EdfSignal(np.full(100, 1.0), 100, label="ECG2"),
+        ]
+    )
+
+    ecg, sampling_frequency = _get_capslpdb_ecg(edf)
+
+    np.testing.assert_array_equal(ecg, np.full(100, 2.0))
+    assert sampling_frequency == 100
+
+
+def test_read_capslpdb_rebases_heartbeats(monkeypatch, tmp_path):
+    """Return heartbeat times relative to the first retained scored epoch."""
+    db_dir = tmp_path / "capslpdb"
+    db_dir.mkdir()
+    _write_edf(db_dir / "record.edf")
+    _write_annotation(
+        db_dir / "record.txt",
+        [
+            ("W", "22:00:30", "SLEEP-S0", "30"),
+            ("S1", "22:01:00", "SLEEP-S1", "30"),
+            ("S2", "22:01:30", "SLEEP-S2", "30"),
+        ],
+    )
+    monkeypatch.setattr(
+        "sleepecg.io.capslpdb._list_physionet",
+        lambda **kwargs: ["record.edf"],
+    )
+    monkeypatch.setattr(
+        "sleepecg.io.capslpdb.detect_heartbeats",
+        lambda ecg, fs: np.array([0, 3000, 6000, 9000]),
+    )
+
+    record = next(
+        read_capslpdb(
+            records_pattern="record",
+            offline=True,
+            keep_edfs=True,
+            data_dir=tmp_path,
+        )
+    )
+
+    assert record.id == "record"
+    assert record.recording_start_time == datetime.time(22, 0, 30)
+    assert record.sleep_stage_duration == 30
+    assert record.sleep_stages.tolist() == [
+        SleepStage.WAKE,
+        SleepStage.N1,
+        SleepStage.N2,
+    ]
+    np.testing.assert_array_equal(record.heartbeat_times, [0, 30, 60])
+
+
+def test_read_capslpdb_skips_n16(monkeypatch, tmp_path):
+    """Skip n16 with a warning because it has no ECG channel."""
+
+    def _list(**kwargs):
+        assert kwargs["pattern"] == "n16.edf"
+        return ["n16.edf"]
+
+    monkeypatch.setattr(
+        "sleepecg.io.capslpdb._list_physionet",
+        _list,
+    )
+
+    with pytest.warns(RuntimeWarning, match="Skipping n16"):
+        records = list(
+            read_capslpdb(records_pattern="n16", offline=True, data_dir=tmp_path)
+        )
+
+    assert records == []
+
+
+def test_read_capslpdb_removes_downloaded_edf(monkeypatch, tmp_path):
+    """Remove a newly downloaded EDF when `keep_edfs` is false."""
+    db_dir = tmp_path / "capslpdb"
+
+    def _download(**kwargs):
+        db_dir.mkdir(exist_ok=True)
+        _write_edf(db_dir / "record.edf")
+        _write_annotation(
+            db_dir / "record.txt",
+            [("W", "22:00:00", "SLEEP-S0", "30")],
+        )
+
+    monkeypatch.setattr(
+        "sleepecg.io.capslpdb._list_physionet",
+        lambda **kwargs: ["record.edf"],
+    )
+    monkeypatch.setattr("sleepecg.io.capslpdb.download_physionet", _download)
+    monkeypatch.setattr(
+        "sleepecg.io.capslpdb.detect_heartbeats",
+        lambda ecg, fs: np.array([100]),
+    )
+
+    next(read_capslpdb(data_dir=tmp_path))
+
+    assert not (db_dir / "record.edf").exists()
+    assert (db_dir / "record.txt").exists()

--- a/tests/test_capslpdb.py
+++ b/tests/test_capslpdb.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import datetime
+import json
 from pathlib import Path
 
 import numpy as np
@@ -229,6 +230,68 @@ def test_read_capslpdb_rebases_heartbeats(monkeypatch, tmp_path):
         SleepStage.N2,
     ]
     np.testing.assert_array_equal(record.heartbeat_times, [0, 30, 60])
+    metadata = json.loads(
+        (db_dir / "preprocessed/heartbeats/record.json").read_text(encoding="utf-8")
+    )
+    assert metadata == {
+        "recording_start_time": "22:00:00",
+        "recording_duration": 120.0,
+    }
+
+
+def test_read_capslpdb_cached_does_not_download_or_read_edf(monkeypatch, tmp_path):
+    """Use cached heartbeat and recording data without accessing an EDF."""
+    db_dir = tmp_path / "capslpdb"
+    heartbeats_dir = db_dir / "preprocessed/heartbeats"
+    heartbeats_dir.mkdir(parents=True)
+    np.save(heartbeats_dir / "record.npy", np.array([0, 30, 90]))
+    (heartbeats_dir / "record.json").write_text(
+        json.dumps(
+            {
+                "recording_start_time": "22:00:00",
+                "recording_duration": 120.0,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def _download(**kwargs):
+        assert kwargs["extensions"] == [".txt"]
+        _write_annotation(
+            db_dir / "record.txt",
+            [
+                ("W", "22:00:30", "SLEEP-S0", "30"),
+                ("S1", "22:01:00", "SLEEP-S1", "30"),
+                ("S2", "22:01:30", "SLEEP-S2", "30"),
+            ],
+        )
+
+    monkeypatch.setattr(
+        "sleepecg.io.capslpdb._list_physionet",
+        lambda **kwargs: ["record.edf"],
+    )
+    monkeypatch.setattr("sleepecg.io.capslpdb.download_physionet", _download)
+    monkeypatch.setattr(
+        "edfio.read_edf",
+        lambda *args, **kwargs: pytest.fail("cached mode must not read an EDF"),
+    )
+
+    record = next(
+        read_capslpdb(
+            records_pattern="record",
+            heartbeats_source="cached",
+            data_dir=tmp_path,
+        )
+    )
+
+    assert not (db_dir / "record.edf").exists()
+    assert record.recording_start_time == datetime.time(22, 0, 30)
+    assert record.sleep_stages.tolist() == [
+        SleepStage.WAKE,
+        SleepStage.N1,
+        SleepStage.N2,
+    ]
+    np.testing.assert_array_equal(record.heartbeat_times, [0, 30])
 
 
 def test_read_capslpdb_skips_n16(monkeypatch, tmp_path):
@@ -257,11 +320,14 @@ def test_read_capslpdb_removes_downloaded_edf(monkeypatch, tmp_path):
 
     def _download(**kwargs):
         db_dir.mkdir(exist_ok=True)
-        _write_edf(db_dir / "record.edf")
-        _write_annotation(
-            db_dir / "record.txt",
-            [("W", "22:00:00", "SLEEP-S0", "30")],
-        )
+        if kwargs["extensions"] == [".edf"]:
+            _write_edf(db_dir / "record.edf")
+        else:
+            assert kwargs["extensions"] == [".txt"]
+            _write_annotation(
+                db_dir / "record.txt",
+                [("W", "22:00:00", "SLEEP-S0", "30")],
+            )
 
     monkeypatch.setattr(
         "sleepecg.io.capslpdb._list_physionet",
@@ -277,3 +343,5 @@ def test_read_capslpdb_removes_downloaded_edf(monkeypatch, tmp_path):
 
     assert not (db_dir / "record.edf").exists()
     assert (db_dir / "record.txt").exists()
+    assert (db_dir / "preprocessed/heartbeats/record.npy").exists()
+    assert (db_dir / "preprocessed/heartbeats/record.json").exists()


### PR DESCRIPTION
Closes #35.

This adds `read_capslpdb()` for the CAP Sleep Database. The reader:

- uses the REMlogic `Event` field for sleep stages and maps S3 and S4 to N3;
- aligns 30-second annotations with the EDF recording and handles missing internal rows;
- supports EKG, ECG, ECG1-ECG2, and separate ECG1/ECG2 channels;
- warns and skips `n16` because it does not contain an ECG channel;
- supports cached heartbeats and the existing PhysioNet download options.

I checked the parser against all 108 public annotation files, containing 108,720 valid sleep-stage rows. `nfle27` has one malformed row, which is skipped with a warning. I also ran the complete reader on `n12`, producing 990 sleep-stage epochs and 30,656 heartbeat times.

The tests cover stage mapping, time and header variants, missing rows, EDF boundaries, midnight alignment, malformed rows, irregular grids, bipolar ECG, heartbeat rebasing, `n16`, and downloaded EDF cleanup.