### PR TITLE
Build arm64 and x86_64 wheels on macos-15

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -31,7 +31,7 @@ jobs:
     name: Build wheel (${{ matrix.os }})
     strategy:
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2025, macos-15]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2025, macos-15-intel, macos-15]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Fix 84becab to build both arm64 and x86_64 wheels, not only arm wheels.

Really does what #280 was supposed to do.