### PR TITLE
Move docs from optional-dependencies to dependency-groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,10 +41,6 @@ cibw = [  # cibuildwheel uses this for running the test suite
     "numba >= 0.61.0",
     "wfdb >= 4.2.0",
 ]
-docs = [  # RTD uses this when building the documentation
-    "mkdocs-material >= 9.5.0",
-    "mkdocstrings-python >= 1.11.1",
-]
 full = [  # complete package functionality
     "edfio >= 0.4.4",
     "joblib >= 1.4.2",
@@ -56,13 +52,17 @@ full = [  # complete package functionality
 
 [dependency-groups]
 dev = [
-    "sleepecg[docs]",
     "sleepecg[full]",
     "pre-commit >= 2.13.0",
     "pytest >= 6.2.0",
     "pytest-cov >= 6.0.0",
     "types-requests",
     "types-pyyaml",
+    "group:docs",
+]
+docs = [
+    "mkdocs-material >= 9.5.0",
+    "mkdocstrings-python >= 1.11.1",
 ]
 
 [project.urls]

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -7,13 +7,10 @@ build:
   os: ubuntu-24.04
   tools:
     python: "3.12"
+  jobs:
+    install:
+      - pip install -e .
+      - pip install --group 'docs'
 
 mkdocs:
   configuration: mkdocs.yml
-
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs


### PR DESCRIPTION
- Move `docs` group from `[project.optional-dependencies]` to `[dependency-groups]`
- Update `readthedocs.yml` to use `build.jobs.install` with `pip install --group docs`
- Reference `docs` group in `dev` group using `group:docs`