### PR TITLE
Switch to pytest 9 configuration in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,8 @@ full = [  # complete package functionality
 
 [dependency-groups]
 dev = [
-    "pytest >= 6.2.0",
-    "pytest-cov >= 6.0.0",
+    "pytest >= 9.1.0",
+    "pytest-cov >= 7.1.0",
     {include-group = "lint"},
     {include-group = "docs"},
 ]
@@ -100,7 +100,11 @@ repair-wheel-command = [
   "pipx run abi3audit --strict --report {wheel}",
 ]
 
-[tool.pytest.ini_options]
+[tool.pytest]
+minversion = "9"
+testpaths = ["tests"]
+log_level = "INFO"
+strict = true
 markers = ["c_extension"]
 filterwarnings = ["error"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -3177,8 +3177,8 @@ provides-extras = ["cibw", "full"]
 dev = [
     { name = "mkdocs-material", specifier = ">=9.5.0" },
     { name = "mkdocstrings-python", specifier = ">=1.11.1" },
-    { name = "pytest", specifier = ">=6.2.0" },
-    { name = "pytest-cov", specifier = ">=6.0.0" },
+    { name = "pytest", specifier = ">=9.1.0" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "ruff", specifier = ">=0.16.1" },
     { name = "ty", specifier = ">=0.0.67" },
     { name = "types-pyyaml" },


### PR DESCRIPTION
Also add options suggested by the Scientific Python Development Guide:
https://learn.scientific-python.org/development/guides/repo-review/?repo=cbrnr%2Fsleepecg&ref=HEAD