### PR TITLE
Enforce line length for docstrings, comments, and literals

### DIFF
--- a/examples/benchmark/utils.py
+++ b/examples/benchmark/utils.py
@@ -22,8 +22,7 @@ class HeartpyWarning(Warning):
 
 
 def reader_dispatch(db_slug: str, data_dir: str | Path) -> Iterator[ECGRecord]:
-    """
-    Read ECG records from mitdb, ltdb or gudb.
+    """Read ECG records from mitdb, ltdb or gudb.
 
     Parameters
     ----------
@@ -50,8 +49,7 @@ def reader_dispatch(db_slug: str, data_dir: str | Path) -> Iterator[ECGRecord]:
 
 
 def detector_dispatch(ecg: np.ndarray, fs: float, detector: str) -> np.ndarray:
-    """
-    Provide a common interface for different heartbeat detectors.
+    """Provide a common interface for different heartbeat detectors.
 
     Parameters
     ----------
@@ -125,8 +123,7 @@ def evaluate_single(
     max_distance: float,
     calc_rri_similarity: bool,
 ) -> dict[str, Any]:
-    """
-    Evaluate a heartbeat detector on a given annotated ECG record.
+    """Evaluate a heartbeat detector on a given annotated ECG record.
 
     Optionally, similarity measures between detected and annotated RR intervals can be
     calculated. As this requires interpolation, it may take some time for long signals.
@@ -140,11 +137,11 @@ def evaluate_single(
     signal_len : int
         Length to which the signal should be sliced.
     max_distance : float
-        Maximum temporal distance in seconds between detected and annotated beats to count
-        as a successful detection.
+        Maximum temporal distance in seconds between detected and annotated beats to
+        count as a successful detection.
     calc_rri_similarity : bool
-        If `True`, calculate similarity measures between detected and annotated RR intervals
-        (computationally expensive for long signals).
+        If `True`, calculate similarity measures between detected and annotated RR
+        intervals (computationally expensive for long signals).
 
     Returns
     -------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,13 +109,16 @@ markers = ["c_extension"]
 filterwarnings = ["error"]
 
 [tool.ruff.lint]
-extend-select = ["C4", "D", "PERF", "W"]
+extend-select = ["C4", "D", "E501", "PERF", "W"]
 ignore = ["D105", "DTZ"]
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401", "F403"]
 "**/examples/*.py" = ["D100"]
 "setup.py" = ["D10"]
+
+[tool.ruff.lint.pycodestyle]
+max-doc-length = 88
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"

--- a/src/sleepecg/classification.py
+++ b/src/sleepecg/classification.py
@@ -28,8 +28,7 @@ def prepare_data_keras(
     stages_mode: str,
     mask_value: int = -1,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """
-    Mask and pad data and calculate sample weights for a Keras model.
+    """Mask and pad data and calculate sample weights for a Keras model.
 
     The following steps are performed:
 
@@ -45,14 +44,15 @@ def prepare_data_keras(
     Parameters
     ----------
     features : list[np.ndarray]
-        Each 2D array in this list is a feature matrix of shape `(n_samples, n_features)`
-        corresponding to a single record as returned by `extract_features()`.
+        Each 2D array in this list is a feature matrix of shape `(n_samples,
+        n_features)` corresponding to a single record as returned by
+        `extract_features()`.
     stages : list[np.ndarray]
-        Each 1D array in this list contains the sleep stages of a single record as returned
-        by `extract_features()`.
+        Each 1D array in this list contains the sleep stages of a single record as
+        returned by `extract_features()`.
     stages_mode : str
-        Identifier of the grouping mode. Can be any of `'wake-sleep'`, `'wake-rem-nrem'`,
-        `'wake-rem-light-n3'`, `'wake-rem-n1-n2-n3'`.
+        Identifier of the grouping mode. Can be any of `'wake-sleep'`,
+        `'wake-rem-nrem'`, `'wake-rem-light-n3'`, `'wake-rem-n1-n2-n3'`.
     mask_value : int, optional
         Value used to pad features and replace `np.nan` and `np.inf`, by default `-1`.
         Remember to pass the same value to `layers.Masking` in your model.
@@ -60,12 +60,12 @@ def prepare_data_keras(
     Returns
     -------
     features_padded : np.ndarray
-        A 3D array of shape `(n_records, max_n_samples, n_features)`, where `n_records` is
-        the length of `features`/`stages` and `max_n_samples` is the maximum number of rows
-        of all feature matrices in `features`.
+        A 3D array of shape `(n_records, max_n_samples, n_features)`, where `n_records`
+        is the length of `features`/`stages` and `max_n_samples` is the maximum number
+        of rows of all feature matrices in `features`.
     stages_padded_onehot : np.ndarray
-        A 3D array of shape `(n_records, max_n_samples, n_classes+1)`, where `n_classes` is
-        the number of classes remaining after merging sleep stages (excluding
+        A 3D array of shape `(n_records, max_n_samples, n_classes+1)`, where `n_classes`
+        is the number of classes remaining after merging sleep stages (excluding
         `SleepStage.UNDEFINED`).
     sample_weight : np.ndarray
         A 2D array of shape `(n_records, max_n_samples)`.
@@ -82,8 +82,8 @@ def prepare_data_keras(
     features_padded[~np.isfinite(features_padded)] = mask_value
 
     stage_counts = stages_padded_onehot.sum(0).sum(0)
-    # samples corresponding to SleepStage.UNDEFINED are ignored, so their count shouldn't
-    # influence the class weights -> slice with [1:]
+    # samples corresponding to SleepStage.UNDEFINED are ignored, so their count
+    # shouldn't influence the class weights -> slice with [1:]
     class_weight = np.sum(stage_counts[1:]) / stage_counts
     sample_weight = class_weight[stages_padded]
 
@@ -91,19 +91,18 @@ def prepare_data_keras(
 
 
 def print_class_balance(stages: np.ndarray, stages_mode: str | None = None) -> None:
-    """
-    Print the number of samples and percentages of each class in `stages`.
+    """Print the number of samples and percentages of each class in `stages`.
 
     Parameters
     ----------
     stages : np.ndarray
-        A 2D array of shape `(n_records, n_samples)` containing integer class labels or a
-        3D array of shape `(n_records, n_samples, n_classes)` containing one-hot encoded
-        class labels.
+        A 2D array of shape `(n_records, n_samples)` containing integer class labels or
+        a 3D array of shape `(n_records, n_samples, n_classes)` containing one-hot
+        encoded class labels.
     stages_mode : str, optional
-        Identifier of the grouping mode. Can be any of `'wake-sleep'`, `'wake-rem-nrem'`,
-        `'wake-rem-light-n3'`, `'wake-rem-n1-n2-n3'`. If `None` (default), no class labels
-        are printed.
+        Identifier of the grouping mode. Can be any of `'wake-sleep'`,
+        `'wake-rem-nrem'`, `'wake-rem-light-n3'`, `'wake-rem-n1-n2-n3'`. If `None`
+        (default), no class labels are printed.
     """
     if stages.ndim == 3:
         stages = stages.argmax(2)
@@ -134,12 +133,11 @@ def save_classifier(
     mask_value: int | None = None,
     classifiers_dir: str | Path | None = None,
 ) -> None:
-    """
-    Save a trained classifier to disk.
+    """Save a trained classifier to disk.
 
     The `model` itself and a `.yml` file containing classifier metadata are stored as
-    `<name>.zip` in `classifiers_dir`. Model serialization is performed as suggested by the
-    respective package documentation. Currently only Keras models are supported.
+    `<name>.zip` in `classifiers_dir`. Model serialization is performed as suggested by
+    the respective package documentation. Currently only Keras models are supported.
 
     Parameters
     ----------
@@ -148,8 +146,8 @@ def save_classifier(
     model : Any
         The classification model, should have `fit()` and `predict()` methods.
     stages_mode : str
-        Identifier of the grouping mode. Can be any of `'wake-sleep'`, `'wake-rem-nrem'`,
-        `'wake-rem-light-n3'`, or `'wake-rem-n1-n2-n3'`.
+        Identifier of the grouping mode. Can be any of `'wake-sleep'`,
+        `'wake-rem-nrem'`, `'wake-rem-light-n3'`, or `'wake-rem-n1-n2-n3'`.
     feature_extraction_params : dict[str, typing.Any]
         The parameters passed to `extract_features()`, as a dictionary mapping string
         parameter names to values. Should not include `records` and `n_jobs`.
@@ -198,28 +196,27 @@ class _Model(Protocol):
 
 @dataclass
 class SleepClassifier:
-    """
-    Store a sleep classifier model and metadata.
+    """Store a sleep classifier model and metadata.
 
     Attributes
     ----------
     model : _Model
         The classification model, should have `fit` and `predict` methods.
     stages_mode : str
-        Identifier of the grouping mode. Can be any of `'wake-sleep'`, `'wake-rem-nrem'`,
-        `'wake-rem-light-n3'`, or `'wake-rem-n1-n2-n3'`.
+        Identifier of the grouping mode. Can be any of `'wake-sleep'`,
+        `'wake-rem-nrem'`, `'wake-rem-light-n3'`, or `'wake-rem-n1-n2-n3'`.
     feature_extraction_params : dict[str, typing.Any]
         The parameters passed to `extract_features()`, as a dictionary mapping string
         parameter names to values. Does not include `records` and `n_jobs`.
     model_type : str
-        A string identifying the model type, e.g. `'keras'` or `'sklearn'`. This is used by
-        `stage()` to determine how to perform sleep stage predictions.
+        A string identifying the model type, e.g. `'keras'` or `'sklearn'`. This is used
+        by `stage()` to determine how to perform sleep stage predictions.
     mask_value : int, optional
-        Only required for models of type `'keras'`, as passed to `prepare_data_keras()` and
-        `keras.layers.Masking`, by default `None`.
+        Only required for models of type `'keras'`, as passed to `prepare_data_keras()`
+        and `keras.layers.Masking`, by default `None`.
     source_file : pathlib.Path, optional
-        The file from which the classifier was loaded using `load_classifier()`, by default
-        `None`.
+        The file from which the classifier was loaded using `load_classifier()`, by
+        default `None`.
     """
 
     model: _Model
@@ -252,29 +249,28 @@ def load_classifier(
     classifiers_dir: str | Path | None = None,
     silence_tf_messages: bool = True,
 ) -> SleepClassifier:
-    """
-    Load a `SleepClassifier` from disk.
+    """Load a `SleepClassifier` from disk.
 
-    This functions reads `.zip` files saved by `save_classifier()`. Pass `'SleepECG'` as the
-    second argument to load a classifier bundled with SleepECG.
+    This functions reads `.zip` files saved by `save_classifier()`. Pass `'SleepECG'` as
+    the second argument to load a classifier bundled with SleepECG.
 
     Parameters
     ----------
     name : str
         The identifier of the classifier to load.
     classifiers_dir : str | pathlib.Path, optional
-        Directory in which to look for `<name>.zip`. If `None` (default), the value is taken
-        from the configuration. If `'SleepECG'`, load classifiers from
+        Directory in which to look for `<name>.zip`. If `None` (default), the value is
+        taken from the configuration. If `'SleepECG'`, load classifiers from
         `site-packages/sleepecg/classifiers`.
     silence_tf_messages : bool, optional
-        Whether or not to silence messages from TensorFlow when loading a model. By default
-        `True`.
+        Whether or not to silence messages from TensorFlow when loading a model. By
+        default `True`.
 
     Returns
     -------
     SleepClassifier
-        Contains the model and metadata required for feature extraction and preprocessing.
-        Can be passed to `stage()`.
+        Contains the model and metadata required for feature extraction and
+        preprocessing. Can be passed to `stage()`.
 
     See Also
     --------
@@ -310,7 +306,8 @@ def load_classifier(
 
         else:
             raise ValueError(
-                f"Loading model of type {classifier_info['model_type']} is not supported"
+                f"Loading model of type {classifier_info['model_type']} is not "
+                "supported"
             )
 
     return SleepClassifier(
@@ -321,15 +318,14 @@ def load_classifier(
 
 
 def list_classifiers(classifiers_dir: str | Path | None = None) -> None:
-    """
-    List available classifiers.
+    """List available classifiers.
 
     Parameters
     ----------
     classifiers_dir : str | pathlib.Path, optional
-        Directory in which to look for classifiers. If `None` (default), the value is taken
-        from the configuration. If `'SleepECG'`, `site-packages/sleepecg/classifiers` is
-        used.
+        Directory in which to look for classifiers. If `None` (default), the value is
+        taken from the configuration. If `'SleepECG'`,
+        `site-packages/sleepecg/classifiers` is used.
 
     See Also
     --------
@@ -364,8 +360,7 @@ def list_classifiers(classifiers_dir: str | Path | None = None) -> None:
 
 
 def _confusion_matrix(y_true: np.ndarray, y_pred: np.ndarray, N: int) -> np.ndarray:
-    """
-    Compute confusion matrix.
+    """Compute confusion matrix.
 
     Parameters
     ----------
@@ -386,8 +381,7 @@ def _confusion_matrix(y_true: np.ndarray, y_pred: np.ndarray, N: int) -> np.ndar
 
 
 def _cohen_kappa(confmat: np.ndarray) -> float:
-    """
-    Compute Cohen's kappa (which measures inter-annotator agreement).
+    """Compute Cohen's kappa (which measures inter-annotator agreement).
 
     Implementation modified from `sklearn.metrics.cohen_kappa_score`.
 
@@ -417,11 +411,10 @@ def evaluate(
     stages_mode: str,
     show_undefined: bool = False,
 ) -> tuple[np.ndarray, list[str]]:
-    """
-    Evaluate the performance of a sleep stage classifier.
+    """Evaluate the performance of a sleep stage classifier.
 
-    Prints overall accuracy, Cohen's kappa, confusion matrix, per-class precision, recall,
-    and F1 score.
+    Prints overall accuracy, Cohen's kappa, confusion matrix, per-class precision,
+    recall, and F1 score.
 
     Parameters
     ----------
@@ -434,11 +427,11 @@ def evaluate(
         containing integer class labels, or a 3D array of shape
         `(n_records, n_samples, n_classes)` containing one-hot encoded class labels.
     stages_mode : str
-        Identifier of the grouping mode. Can be any of `'wake-sleep'`, `'wake-rem-nrem'`,
-        `'wake-rem-light-n3'`, `'wake-rem-n1-n2-n3'`.
+        Identifier of the grouping mode. Can be any of `'wake-sleep'`,
+        `'wake-rem-nrem'`, `'wake-rem-light-n3'`, `'wake-rem-n1-n2-n3'`.
     show_undefined : bool, optional
-        If `True`, include `SleepStage.UNDEFINED` (i.e `0`) in the confusion matrix output.
-        This can be helpful during debugging. By default `False`.
+        If `True`, include `SleepStage.UNDEFINED` (i.e `0`) in the confusion matrix
+        output. This can be helpful during debugging. By default `False`.
 
     Returns
     -------
@@ -496,11 +489,10 @@ def stage(
     record: SleepRecord,
     return_mode: str = "int",
 ) -> np.ndarray:
-    """
-    Predict sleep stages for a single record.
+    """Predict sleep stages for a single record.
 
-    Feature extraction and preprocessing are performed according to the information stored
-    in `clf`.
+    Feature extraction and preprocessing are performed according to the information
+    stored in `clf`.
 
     Parameters
     ----------
@@ -520,8 +512,8 @@ def stage(
 
     Warnings
     --------
-    Note that the returned labels depend on `clf.stages_mode`, so they do not necessarily
-    follow the stage-to-integer mapping defined in `SleepStage`. See
+    Note that the returned labels depend on `clf.stages_mode`, so they do not
+    necessarily follow the stage-to-integer mapping defined in `SleepStage`. See
     [classification](../classification.md) for details.
     """
     return_modes = {"int", "prob", "str"}

--- a/src/sleepecg/config.py
+++ b/src/sleepecg/config.py
@@ -31,12 +31,12 @@ def _read_yaml(path: Path) -> dict[str, Any]:
 
 
 def get_config() -> dict[str, str]:
-    """
-    Read SleepECG configuration.
+    """Read SleepECG configuration.
 
-    For parameters not set in the user configuration file (`~/.sleepecg/config.yml`), this
-    falls back to the default values defined in `site-packages/sleepecg/config.yml`. See
-    [configuration](../configuration.md) for a list of possible settings.
+    For parameters not set in the user configuration file (`~/.sleepecg/config.yml`),
+    this falls back to the default values defined in
+    `site-packages/sleepecg/config.yml`. See [configuration](../configuration.md) for a
+    list of possible settings.
 
     Returns
     -------
@@ -47,19 +47,20 @@ def get_config() -> dict[str, str]:
     user_config = _read_yaml(_USER_CONFIG_PATH)
     if invalid_keys := set(user_config) - set(config):
         raise ValueError(
-            f"Invalid key(s) found in user config at {_USER_CONFIG_PATH}: {invalid_keys}"
+            f"Invalid key(s) found in user config at {_USER_CONFIG_PATH}: "
+            f"{invalid_keys}"
         )
     config.update(user_config)
     return config
 
 
 def get_config_value(key: str) -> str:
-    """
-    Read specific SleepECG configuration value.
+    """Read specific SleepECG configuration value.
 
-    For parameters not set in the user configuration file (`~/.sleepecg/config.yml`), this
-    falls back to the default values defined in `site-packages/sleepecg/config.yml`. See
-    [configuration](../configuration.md) for a list of possible settings.
+    For parameters not set in the user configuration file (`~/.sleepecg/config.yml`),
+    this falls back to the default values defined in
+    `site-packages/sleepecg/config.yml`. See [configuration](../configuration.md) for a
+    list of possible settings.
 
     Parameters
     ----------
@@ -82,11 +83,10 @@ def get_config_value(key: str) -> str:
 
 
 def set_config(**kwargs: Any) -> None:
-    """
-    Set SleepECG preferences and store them to the user configuration file.
+    """Set SleepECG preferences and store them to the user configuration file.
 
-    If a value is `None`, the corresponding key is deleted from the user configuration. See
-    [configuration](../configuration.md) for a list of possible settings.
+    If a value is `None`, the corresponding key is deleted from the user configuration.
+    See [configuration](../configuration.md) for a list of possible settings.
 
     Parameters
     ----------
@@ -105,7 +105,8 @@ def set_config(**kwargs: Any) -> None:
         if key not in default_config:
             options = ", ".join(default_config)
             raise ValueError(
-                f"Trying to set invalid config key: {key!r}, possible options: {options}"
+                f"Trying to set invalid config key: {key!r}, possible options: "
+                f"{options}"
             )
 
     for key, value in kwargs.items():

--- a/src/sleepecg/feature_extraction.py
+++ b/src/sleepecg/feature_extraction.py
@@ -75,11 +75,10 @@ _TIME_DOMAIN_EXPECTED_WARNING_MESSAGES = (
 
 
 def _create_ragged_array(data: list[np.ndarray]) -> np.ndarray:
-    """
-    Convert a list of arrays with different lengths to a numpy array.
+    """Convert a list of arrays with different lengths to a numpy array.
 
-    Each element in `data` is a row in the resulting array. Rows shorter than the longest
-    row will be padded with `np.nan`.
+    Each element in `data` is a row in the resulting array. Rows shorter than the
+    longest row will be padded with `np.nan`.
 
     Parameters
     ----------
@@ -105,10 +104,10 @@ def _split_into_windows(
     lookback: int,
     lookforward: int,
 ) -> list[np.ndarray]:
-    """
-    Split (irregularly sampled) data into windows of equal temporal length.
+    """Split (irregularly sampled) data into windows of equal temporal length.
 
-    Make sure `data_times`, `window_times`, `lookback` and `lookforward` use the same units.
+    Make sure `data_times`, `window_times`, `lookback` and `lookforward` use the same
+    units.
 
     Parameters
     ----------
@@ -142,11 +141,10 @@ def _split_into_windows(
 def _nanpsd(
     x: np.ndarray, fs: float, max_nans: float = 0
 ) -> tuple[np.ndarray, np.ndarray]:
-    """
-    Compute power spectral density (PSD) along axis 1, ignoring NaNs.
+    """Compute power spectral density (PSD) along axis 1, ignoring NaNs.
 
-    For rows containing a fraction of NaNs higher than `max_nans`, the output array `Pxx` is
-    filled with `np.nan`.
+    For rows containing a fraction of NaNs higher than `max_nans`, the output array
+    `Pxx` is filled with `np.nan`.
 
     Parameters
     ----------
@@ -156,7 +154,8 @@ def _nanpsd(
         Sampling frequency in Hz.
     max_nans : float, optional
         Maximum fraction of NaNs in a signal (i.e. row of `x`), for which the PSD
-        computation is attempted. Should be a value between `0.0` and `1.0`, by default `0`.
+        computation is attempted. Should be a value between `0.0` and `1.0`, by default
+        `0`.
 
     Returns
     -------
@@ -193,8 +192,7 @@ def _hrv_timedomain_features(
     lookback: int,
     lookforward: int,
 ) -> np.ndarray:
-    """
-    Calculate 26 time domain heart rate variability (HRV) features.
+    """Calculate 26 time domain heart rate variability (HRV) features.
 
     Features are implemented according to [1]_, [2]_ and [3]_.
 
@@ -219,16 +217,16 @@ def _hrv_timedomain_features(
 
     Notes
     -----
-    .. [1] Task Force of the European Society of Cardiology. (1996). Heart rate variability:
-       standards of measurement, physiological interpretation and clinical use. Circulation,
-       93, 1043-1065. https://doi.org/10.1161/01.CIR.93.5.1043
+    .. [1] Task Force of the European Society of Cardiology. (1996). Heart rate
+       variability: standards of measurement, physiological interpretation and clinical
+       use. Circulation, 93, 1043-1065. https://doi.org/10.1161/01.CIR.93.5.1043
     .. [2] Shaffer, F., & Ginsberg, J. P. (2017). An overview of heart rate variability
        metrics and norms. Frontiers in Public Health, 258.
        https://doi.org/10.3389/fpubh.2017.00258
     .. [3] Toichi, M., Sugiura, T., Murai, T., & Sengoku, A. (1997). A new method of
-       assessing cardiac autonomic function and its comparison with spectral analysis and
-       coefficient of variation of R–R interval. Journal of the Autonomic Nervous System,
-       62(1-2), 79-84. https://doi.org/10.1016/S0165-1838(96)00112-9
+       assessing cardiac autonomic function and its comparison with spectral analysis
+       and coefficient of variation of R–R interval. Journal of the Autonomic Nervous
+       System, 62(1-2), 79-84. https://doi.org/10.1016/S0165-1838(96)00112-9
     """
     NN = _create_ragged_array(
         _split_into_windows(
@@ -315,8 +313,7 @@ def _hrv_frequencydomain_features(
     fs_rri_resample: float,
     max_nans: float,
 ) -> np.ndarray:
-    """
-    Calculate seven frequency domain heart rate variability (HRV) features.
+    """Calculate seven frequency domain heart rate variability (HRV) features.
 
     Features are implemented according to [1]_.
 
@@ -348,9 +345,9 @@ def _hrv_frequencydomain_features(
 
     Notes
     -----
-    .. [1] Task Force of the European Society of Cardiology. (1996). Heart rate variability:
-       standards of measurement, physiological interpretation and clinical use. Circulation,
-       93, 1043-1065. https://doi.org/10.1161/01.CIR.93.5.1043
+    .. [1] Task Force of the European Society of Cardiology. (1996). Heart rate
+       variability: standards of measurement, physiological interpretation and clinical
+       use. Circulation, 93, 1043-1065. https://doi.org/10.1161/01.CIR.93.5.1043
     """
     rri_interp_times = np.arange(
         stage_times[0] - lookback,
@@ -388,12 +385,11 @@ def _hrv_frequencydomain_features(
 
 
 def _metadata_features(record: SleepRecord, num_stages: int) -> np.ndarray:
-    """
-    Create a feature matrix from record metadata.
+    """Create a feature matrix from record metadata.
 
-    Recording start time, gender, age, and weight are used as (constant) features. In case
-    of missing information (i.e. the required attribute of `SleepRecord` is `None`), the
-    corresponding column is filled with `np.nan`.
+    Recording start time, gender, age, and weight are used as (constant) features. In
+    case of missing information (i.e. the required attribute of `SleepRecord` is
+    `None`), the corresponding column is filled with `np.nan`.
 
     Parameters
     ----------
@@ -432,12 +428,11 @@ def _metadata_features(record: SleepRecord, num_stages: int) -> np.ndarray:
 def _parse_feature_selection(
     requested_ids: list[str],
 ) -> tuple[list[str], list[str], list[int]]:
-    """
-    Parse a list containing feature group names and single feature IDs.
+    """Parse a list containing feature group names and single feature IDs.
 
     Each feature group is expanded to all its feature identifiers as listed in
-    `feature_extraction._FEATURE_GROUPS`, preserving input order. If an invalid (group) ID
-    is found, a `ValueError` is raised.
+    `feature_extraction._FEATURE_GROUPS`, preserving input order. If an invalid (group)
+    ID is found, a `ValueError` is raised.
 
     Parameters
     ----------
@@ -483,11 +478,10 @@ def _parse_feature_selection(
 def _check_frequencydomain_window_time(
     window_time: int, feature_ids: list[str]
 ) -> None:
-    """
-    Warn if the duration of the analysis window is too short for a frequency domain feature.
+    """Warn if the analysis window is too short for frequency-domain features.
 
-    Each window duration should be at least 10 times the wavelength of the lower frequency
-    bound of the investigated component.
+    Each window duration should be at least 10 times the wavelength of the lower
+    frequency bound of the investigated component.
 
     Parameters
     ----------
@@ -521,19 +515,18 @@ def preprocess_rri(
     min_rri: float | None = None,
     max_rri: float | None = None,
 ) -> np.ndarray:
-    """
-    Replace invalid RRI samples with `np.nan`.
+    """Replace invalid RRI samples with `np.nan`.
 
     Parameters
     ----------
     rri : np.ndarray
         An array containing consecutive RR interval lengths in seconds.
     min_rri : float, optional
-        Minimum RRI in seconds to be considered valid. If `None` (default), no lower bounds
-        check is performed.
+        Minimum RRI in seconds to be considered valid. If `None` (default), no lower
+        bounds check is performed.
     max_rri : float, optional
-        Maximum RRI in seconds to be considered valid. If `None` (default), no upper bounds
-        check is performed.
+        Maximum RRI in seconds to be considered valid. If `None` (default), no upper
+        bounds check is performed.
 
     Returns
     -------
@@ -569,8 +562,7 @@ def _extract_features_single(
     feature_ids: list[str],
     col_indices: list[int],
 ) -> tuple[np.ndarray, np.ndarray | None]:
-    """
-    Calculate features for a single record.
+    """Calculate features for a single record.
 
     This function is required to allow parallelizing feature extraction.
 
@@ -599,9 +591,9 @@ def _extract_features_single(
         Maximum fraction of NaNs in an analysis window for which frequency features are
         computed. Should be a value between `0.0` and `1.0`.
     feature_ids : list[str]
-        A list containing the identifiers of all features to be extracted. This is only used
-        to avoid issuing a warning about the analysis window being too short for some
-        frequency range which is not requested.
+        A list containing the identifiers of all features to be extracted. This is only
+        used to avoid issuing a warning about the analysis window being too short for
+        some frequency range which is not requested.
     col_indices : list[int]
         The column indices of `feature_ids` in a list of all feature IDs in all
         `required_groups`. Required to select the columns corresponding to the requested
@@ -613,8 +605,8 @@ def _extract_features_single(
         The feature matrix of shape `(len(sleep_stages), <num_features>)` containing the
         extracted features.
     stages : np.ndarray | None
-        The label vector, i.e. the annotated sleep stages. For a `record` without annotated
-        stages, this will be `None`.
+        The label vector, i.e. the annotated sleep stages. For a `record` without
+        annotated stages, this will be `None`.
     """
     rri_required = "hrv-time" in required_groups or "hrv-frequency" in required_groups
 
@@ -681,7 +673,8 @@ def _extract_features_single(
             if len(record.activity_counts) != num_stages:
                 raise ValueError(
                     f"activity_counts for {record.id} contains "
-                    f"{len(record.activity_counts)} values, but {num_stages} are required."
+                    f"{len(record.activity_counts)} values, but {num_stages} are "
+                    "required."
                 )
             X.append(record.activity_counts.reshape(-1, 1))
     features = np.hstack(X)[:, col_indices]
@@ -719,41 +712,41 @@ def extract_features(
     max_nans: float = 0,
     n_jobs: int = 1,
 ) -> tuple[list[np.ndarray], list[np.ndarray | None], list[str]]:
-    """
-    Calculate features from sleep data (e.g. heart rate).
+    """Calculate features from sleep data (e.g. heart rate).
 
-    Time and frequency domain heart rate variability (HRV) features are calculated based on
-    the following publications (see [feature extraction](../feature_extraction.md) for
-    available features and feature groups.):
+    Time and frequency domain heart rate variability (HRV) features are calculated based
+    on the following publications (see [feature extraction](../feature_extraction.md)
+    for available features and feature groups.):
 
     - Task Force of the European Society of Cardiology. (1996). Heart rate variability:
-      standards of measurement, physiological interpretation and clinical use. Circulation,
-      93, 1043-1065. https://doi.org/10.1161/01.CIR.93.5.1043
-    - Shaffer, F., & Ginsberg, J. P. (2017). An overview of heart rate variability metrics
-      and norms. Frontiers in Public Health, 258. https://doi.org/10.3389/fpubh.2017.00258
-    - Toichi, M., Sugiura, T., Murai, T., & Sengoku, A. (1997). A new method of assessing
-      cardiac autonomic function and its comparison with spectral analysis and coefficient
-      of variation of R–R interval. Journal of the Autonomic Nervous System, 62(1-2), 79-84.
-      https://doi.org/10.1016/S0165-1838(96)00112-9
+      standards of measurement, physiological interpretation and clinical use.
+      Circulation, 93, 1043-1065. https://doi.org/10.1161/01.CIR.93.5.1043
+    - Shaffer, F., & Ginsberg, J. P. (2017). An overview of heart rate variability
+      metrics and norms. Frontiers in Public Health, 258.
+      https://doi.org/10.3389/fpubh.2017.00258
+    - Toichi, M., Sugiura, T., Murai, T., & Sengoku, A. (1997). A new method of
+      assessing cardiac autonomic function and its comparison with spectral analysis and
+      coefficient of variation of R–R interval. Journal of the Autonomic Nervous System,
+      62(1-2), 79-84. https://doi.org/10.1016/S0165-1838(96)00112-9
 
     Parameters
     ----------
     records : Iterable[SleepRecord]
-        An iterable of `SleepRecord` objects as yielded by the various reader functions in
-        SleepECG.
+        An iterable of `SleepRecord` objects as yielded by the various reader functions
+        in SleepECG.
     lookback : int, optional
-        Backward extension of the analysis window from each sleep stage time in seconds, by
-        default `0`.
+        Backward extension of the analysis window from each sleep stage time in seconds,
+        by default `0`.
     lookforward : int, optional
-        Forward extension of the analysis window from each sleep stage time in seconds, by
-        default `30`.
+        Forward extension of the analysis window from each sleep stage time in seconds,
+        by default `30`.
     sleep_stage_duration : int, optional
         Duration of a single sleep stage in the returned `stages` in seconds, by default
         `30`.
     feature_selection : list[str], optional
-        Which features to extract. Can be feature groups or single feature identifiers, as
-        listed in [feature extraction](../feature_extraction.md). If `None` (default), all
-        possible features are extracted.
+        Which features to extract. Can be feature groups or single feature identifiers,
+        as listed in [feature extraction](../feature_extraction.md). If `None`
+        (default), all possible features are extracted.
     fs_rri_resample : float, optional
         Frequency in Hz at which the RRI time series should be resampled before spectral
         analysis. Only relevant for frequency domain features, by default `4`.
@@ -774,14 +767,16 @@ def extract_features(
     -------
     features : list[np.ndarray]
         A list containing feature matrices, which are arrays of shape
-        `(len(sleep_stages), <num_features>)` and contain the extracted features per record.
+        `(len(sleep_stages), <num_features>)` and contain the extracted features per
+        record.
     stages : list[np.ndarray | None]
         A list containing label vectors, i.e. the annotated sleep stages. For any
-        `SleepRecord` without annotated stages, the corresponding list entry will be `None`.
+        `SleepRecord` without annotated stages, the corresponding list entry will be
+        `None`.
     feature_ids : list[str]
-        A list containing the identifiers of the extracted features. Feature groups passed
-        in `feature_selection` are expanded to all individual features they contain. The
-        order matches the column order of the feature matrix.
+        A list containing the identifiers of the extracted features. Feature groups
+        passed in `feature_selection` are expanded to all individual features they
+        contain. The order matches the column order of the feature matrix.
     """
     if feature_selection is None:
         feature_selection = list(_FEATURE_GROUPS)

--- a/src/sleepecg/heartbeats.py
+++ b/src/sleepecg/heartbeats.py
@@ -31,8 +31,7 @@ _sos_filters: dict[float, np.ndarray] = {}
 
 
 def detect_heartbeats(ecg: np.ndarray, fs: float, backend: str = "c") -> np.ndarray:
-    """
-    Detect heartbeats in an ECG signal.
+    """Detect heartbeats in an ECG signal.
 
     This is a modified version of the beat detection algorithm using adaptive thresholds
     described by Pan & Tompkins in 1985.
@@ -44,19 +43,20 @@ def detect_heartbeats(ecg: np.ndarray, fs: float, backend: str = "c") -> np.ndar
       Arrhythmia Database, a second order bandpass with cutoff frequencies 5 and 30 Hz
       created via `scipy.signal.butter()` is used.
     - A bidirectional filter is used to remove filter delay.
-    - The integration window is centered on the filtered signal, i.e. a peak in the filtered
-      signal corresponds to a plateau in the integrated signal, not a saddle in the rising
-      edge. This lets the adaptive threshold for the integrated signal remain at a higher
-      level, which is less susceptible to noise.
-    - Learning phase 1 is not described in detail in the original paper. This implementation
-      uses maximum and mean values inside the first two seconds to initialize
-      SPKI/SPKF/NPKI/NPKF. Details are provided in the `_thresholding` code.
-    - In addition to the original searchback criterion, a searchback is also performed if no
-      peak is found during the first second of the signal or no second peak is found 1.5 s
-      after the first one. This ensures correct behaviour at signal start in case an
-      unusually large peak during learning phase 1 messes up threshold initialization.
-    - After an unsuccessful searchback, the procedure is repeated in the same interval with
-      further reduced thresholds, up to 16 times.
+    - The integration window is centered on the filtered signal, i.e. a peak in the
+      filtered signal corresponds to a plateau in the integrated signal, not a saddle in
+      the rising edge. This lets the adaptive threshold for the integrated signal remain
+      at a higher level, which is less susceptible to noise.
+    - Learning phase 1 is not described in detail in the original paper. This
+      implementation uses maximum and mean values inside the first two seconds to
+      initialize SPKI/SPKF/NPKI/NPKF. Details are provided in the `_thresholding` code.
+    - In addition to the original searchback criterion, a searchback is also performed
+      if no peak is found during the first second of the signal or no second peak is
+      found 1.5 s after the first one. This ensures correct behaviour at signal start in
+      case an unusually large peak during learning phase 1 messes up threshold
+      initialization.
+    - After an unsuccessful searchback, the procedure is repeated in the same interval
+      with further reduced thresholds, up to 16 times.
 
     Parameters
     ----------
@@ -64,13 +64,13 @@ def detect_heartbeats(ecg: np.ndarray, fs: float, backend: str = "c") -> np.ndar
         ECG signal. Note that the unit of the data does not matter (the algorithm will
         return similar results regardless of the scaling of the data).
     fs : float
-        Sampling frequency in Hz. For best results, a sampling frequency of at least 100 Hz
-        is recommended.
+        Sampling frequency in Hz. For best results, a sampling frequency of 100 Hz or
+        higher is recommended.
     backend : {'c', 'numba', 'python'}
-        Which implementation of the squared moving integration and thresholding algorithm to
-        use. If available, `'c'` is the fastest implementation, `'numba'` is about 25%
-        slower, and `'python'` is about 20 times slower but provided as a fallback. By
-        default `'c'`.
+        Which implementation of the squared moving integration and thresholding
+        algorithm to use. If available, `'c'` is the fastest implementation, `'numba'`
+        is about 25% slower, and `'python'` is about 20 times slower but provided as a
+        fallback. By default `'c'`.
 
     Returns
     -------
@@ -125,9 +125,9 @@ def detect_heartbeats(ecg: np.ndarray, fs: float, backend: str = "c") -> np.ndar
     # filtering the signal at the first non-flat index.
     filtered_ecg = scipy.signal.sosfiltfilt(sos, ecg[first_nonflat:])
 
-    # scipy.signal.sosfiltfilt returns an array with negative strides. Both `np.correlate`
-    # and `_thresholding` require contiguity, so ensuring this here once reduces total
-    # runtime.
+    # scipy.signal.sosfiltfilt returns an array with negative strides. Both
+    # `np.correlate` and `_thresholding` require contiguity, so ensuring this here once
+    # reduces total runtime.
     filtered_ecg = np.ascontiguousarray(filtered_ecg)
 
     # five-point derivative as described by Pan & Tompkins
@@ -167,14 +167,13 @@ def compare_heartbeats(
     annotation: np.ndarray,
     max_distance: int = 0,
 ) -> _CompareHeartbeatsResult:
-    """
-    Determine correctness of detection results.
+    """Determine correctness of detection results.
 
     Determine true positives (TP), false positives (FP) and false negatives (FN) for an
-    array of detected heartbeat indices based on an array of annotated heartbeat indices.
-    Since neither annotations nor automated detectors usually hit the peak perfectly,
-    detected peaks no further than `max_distance` in both directions from an annotated peak
-    are considered true positives.
+    array of detected heartbeat indices based on an array of annotated heartbeat
+    indices. Since neither annotations nor automated detectors usually hit the peak
+    perfectly, detected peaks no further than `max_distance` in both directions from an
+    annotated peak are considered true positives.
 
     Parameters
     ----------
@@ -229,13 +228,12 @@ def rri_similarity(
     annotation: np.ndarray,
     fs_resample: float = 4,
 ) -> _RRISimilarityResult:
-    """
-    Calculate measures of similarity between RR intervals.
+    """Calculate measures of similarity between RR intervals.
 
-    RR intervals are calculated from detected and annotated heartbeat indices. The RR time
-    series is then resampled to frequency `fs_resample` in the timespan common to both
-    detection and annotation. Pearson's and Spearman's correlation coefficients as well as
-    the root mean square error are returned.
+    RR intervals are calculated from detected and annotated heartbeat indices. The RR
+    time series is then resampled to frequency `fs_resample` in the timespan common to
+    both detection and annotation. Pearson's and Spearman's correlation coefficients as
+    well as the root mean square error are returned.
 
     Parameters
     ----------
@@ -276,8 +274,7 @@ def rri_similarity(
 
 
 def _squared_moving_integration_py(x: np.ndarray, window_length: int) -> np.ndarray:
-    """
-    Perform squaring and moving integration of an array.
+    """Perform squaring and moving integration of an array.
 
     Parameters
     ----------
@@ -301,13 +298,13 @@ def _squared_moving_integration_py(x: np.ndarray, window_length: int) -> np.ndar
     integration_buffer = np.zeros(window_length)
     sum = 0
 
-    # the integration window is centered on the original signal, for even window_length the
-    # behavior of np.convolve with a constant window of even length is replicated (i.e the
-    # window is off-center to the left)
+    # the integration window is centered on the original signal, for even window_length
+    # the behavior of np.convolve with a constant window of even length is replicated
+    # (i.e the window is off-center to the left)
     window_length_half = (window_length + 1) // 2
 
-    # during the first `window_length/2` samples there is no output since the integration
-    # window's center would be at a negative index of the input
+    # during the first `window_length/2` samples there is no output since the
+    # integration window's center would be at a negative index of the input
     for i in range(window_length_half):
         square = x[i] * x[i]
         integration_buffer[i % window_length] = square
@@ -320,8 +317,8 @@ def _squared_moving_integration_py(x: np.ndarray, window_length: int) -> np.ndar
         integration_buffer[i % window_length] = square
         sum += square
 
-    # the end of the x signal is reached, so the integration window is built down and the
-    # last `window_length/2` entries of the output are filled
+    # the end of the x signal is reached, so the integration window is built down and
+    # the last `window_length/2` entries of the output are filled
     for i in range(signal_len, signal_len + window_length_half):
         output[i - window_length_half] = sum
         sum -= integration_buffer[i % window_length]
@@ -334,8 +331,7 @@ def _thresholding_py(
     integrated_ecg: np.ndarray,
     fs: float,
 ) -> np.ndarray:
-    """
-    Perform adaptive thresholding based on Pan and Tompkin's algorithm.
+    """Perform adaptive thresholding based on Pan and Tompkin's algorithm.
 
     Parameters
     ----------
@@ -349,7 +345,8 @@ def _thresholding_py(
     Returns
     -------
     np.ndarray
-        Array containing `1` for every sample in `filtered_ecg` identified as a heartbeat.
+        Array containing `1` for every sample in `filtered_ecg` identified as a
+        heartbeat.
     """
     signal_len = len(filtered_ecg)
     beat_mask = np.zeros_like(filtered_ecg)  # numba can't work with dtype=bool
@@ -357,18 +354,18 @@ def _thresholding_py(
     REFRACTORY_SAMPLES = int(0.2 * fs)  # 200ms
     T_WAVE_WINDOW = int(0.36 * fs)  # 360ms
 
-    # --------------------------------------------------------------------------------------
+    # ----------------------------------------------------------------------------------
     # Learning Phase 1
-    # --------------------------------------------------------------------------------------
-    # Pan & Tompkins mention a learning phase to initialize detection thresholds based upon
-    # signal and noise peaks detected during the first two seconds. The exact initialization
-    # process is not described. The adaptive thresholds are calculated based on running
-    # estimates of signal and noise peaks (`SPKF` and `NPKF` for the filtered signal).
-    # Assuming constant peak amplitudes, those values converge towards the signal peak
-    # amplitude and noise peak amplitude, respectively. Therefore, SPKF/SPKI are assumed to
-    # be the maximum values of the filtered/integrated signal during the learning phase.
-    # Accordingly, NPKF/NPKI are initialized to the mean values during the first two
-    # seconds.
+    # ----------------------------------------------------------------------------------
+    # Pan & Tompkins mention a learning phase to initialize detection thresholds based
+    # upon signal and noise peaks detected during the first two seconds. The exact
+    # initialization process is not described. The adaptive thresholds are calculated
+    # based on running estimates of signal and noise peaks (`SPKF` and `NPKF` for the
+    # filtered signal). Assuming constant peak amplitudes, those values converge towards
+    # the signal peak amplitude and noise peak amplitude, respectively. Therefore,
+    # SPKF/SPKI are assumed to be the maximum values of the filtered/integrated signal
+    # during the learning phase. Accordingly, NPKF/NPKI are initialized to the mean
+    # values during the first two seconds.
     SPKF = np.max(filtered_ecg[: int(2 * fs)])
     NPKF = np.mean(filtered_ecg[: int(2 * fs)])
     SPKI = np.max(integrated_ecg[: int(2 * fs)])
@@ -377,14 +374,15 @@ def _thresholding_py(
     threshold_F1 = NPKF + 0.25 * (SPKF - NPKF)
 
     # According to the original paper, `RR AVERAGE2` is the average of the last 8 RR
-    # intervals that lie in a certain interval. In the worst case, this requires going back
-    # to the very first RR interval. Therefore, all RR intervals are stored. As the
-    # algorithm enforces a refractory period, the maximum number of heartbeats is equal to
-    # signal_len / refractory_samples.
+    # intervals that lie in a certain interval. In the worst case, this requires going
+    # back to the very first RR interval. Therefore, all RR intervals are stored. As the
+    # algorithm enforces a refractory period, the maximum number of heartbeats is equal
+    # to signal_len / refractory_samples.
     RR_intervals = np.zeros(signal_len // REFRACTORY_SAMPLES)
 
-    # tracking the number of peaks found is required to calculate the average RR intervals
-    # correctly during the first 8 beats (also needed for access to RR_intervals)
+    # tracking the number of peaks found is required to calculate the average RR
+    # intervals correctly during the first 8 beats (also needed for access to
+    # RR_intervals)
     num_peaks_found = 0
 
     RR_missed_limit = 0.0
@@ -405,33 +403,36 @@ def _thresholding_py(
 
         signal_peak_found = False
         noise_peak_found = False
-        # ----------------------------------------------------------------------------------
+        # ------------------------------------------------------------------------------
         # Searchback
-        # ----------------------------------------------------------------------------------
-        # During a "searchback", detection thresholds are reduced by one half. The peak with
-        # highest amplitude between 200ms (i.e. the refractory period) after the previous
-        # detected peak and the current index is considered as a peak candidate.
-        # Modifications compared to Pan & Tompkins' original method:
-        # - The original paper states that a searchback peak's amplitude has to be between
-        #   the original threshold and the reduced one. It can happen that this is the case
-        #   for the filtered signal, but not for the integrated one (if the raw signal
-        #   amplitude is suddenly considerably lower). Therefore, this implementation
-        #   requires both signals (filtered and integrated) to be above the reduced
-        #   threshold, but only one of them to be below the original threshold.
+        # ------------------------------------------------------------------------------
+        # During a "searchback", detection thresholds are reduced by one half. The peak
+        # with highest amplitude between 200ms (i.e. the refractory period) after the
+        # previous detected peak and the current index is considered as a peak
+        # candidate. Modifications compared to Pan & Tompkins' original method:
+        # - The original paper states that a searchback peak's amplitude has to be
+        #   between the original threshold and the reduced one. It can happen that this
+        #   is the case for the filtered signal, but not for the integrated one (if the
+        #   raw signal amplitude is suddenly considerably lower). Therefore, this
+        #   implementation requires both signals (filtered and integrated) to be above
+        #   the reduced threshold, but only one of them to be below the original
+        #   threshold.
         # - No further steps are specified for the case that no peak is found during
-        #   searchback. Since a searchback is triggered because (physiologically) there has
-        #   to be a heartbeat during the searchback interval, this implementation repeats
-        #   the process with further reduced thresholds. Up to 16 searchback runs are
-        #   performed, each time the thresholds are further reduced by 1/2. A hard limit of
-        #   16 runs avoids an endless loop in case there is really only noise.
+        #   searchback. Since a searchback is triggered because (physiologically) there
+        #   has to be a heartbeat during the searchback interval, this implementation
+        #   repeats the process with further reduced thresholds. Up to 16 searchback
+        #   runs are performed, each time the thresholds are further reduced by 1/2. A
+        #   hard limit of 16 runs avoids an endless loop in case there is really only
+        #   noise.
         # - Since the criterion for triggering a searchback is based on the average RR
         #   interval, in the original form this could only happen after at least two
-        #   detected heartbeats. An exceptionally large peak during the first learning phase
-        #   can throw the initial thresholds off, so peaks at the beginning are ignored -
-        #   which in turn invalidates learning phase 2. Therefore, in addition to the
-        #   original searchback criterion (no peak during 1.66 * "the average RR interval"),
-        #   a searchback is triggered in two cases: (1) if there is no peak during the first
-        #   second, and (2) if there is no peak 1.5s after the first peak.
+        #   detected heartbeats. An exceptionally large peak during the first learning
+        #   phase can throw the initial thresholds off, so peaks at the beginning are
+        #   ignored - which in turn invalidates learning phase 2. Therefore, in addition
+        #   to the original searchback criterion (no peak during 1.66 * "the average RR
+        #   interval"), a searchback is triggered in two cases: (1) if there is no peak
+        #   during the first second, and (2) if there is no peak 1.5s after the first
+        #   peak.
         if (
             (
                 num_peaks_found > 1
@@ -456,8 +457,8 @@ def _thresholding_py(
                         if PEAKF > filtered_ecg[searchback_index - 1]:
                             # it is a peak
                             PEAKI = integrated_ecg[searchback_index]
-                            # one signal is between the reduced and original threshold, the
-                            # other one above the reduced threshold
+                            # one signal is between the reduced and original threshold,
+                            # the other one above the reduced threshold
                             if (
                                 (
                                     threshold_F1 / searchback_divisor
@@ -479,8 +480,8 @@ def _thresholding_py(
                                 ]
                                 found_a_candidate = True
 
-                        # the amplitude of the next sample is lower, so it can't be a peak
-                        # -> skip it
+                        # the amplitude of the next sample is lower, so it can't be a
+                        # peak -> skip it
                         searchback_index += 1
 
                     searchback_index += 1
@@ -491,13 +492,14 @@ def _thresholding_py(
                     signal_peak_found = True
                     peak_index = best_searchback_index
 
-                    # don't perform a searchback until the next signal peak has been found
-                    # to avoid endless loops
+                    # don't perform a searchback until the next signal peak has been
+                    # found to avoid endless loops
                     do_searchback = False
                     break
 
-            # The thresholds do not change while searchback is active. If this pass found
-            # no candidate, the next pass only needs to inspect samples added since now.
+            # The thresholds do not change while searchback is active. If this pass
+            # found no candidate, the next pass only needs to inspect samples added
+            # since now.
             if not signal_peak_found:
                 searchback_start_index = index
 
@@ -507,9 +509,9 @@ def _thresholding_py(
                 PEAKF = filtered_ecg[index]
                 PEAKI = integrated_ecg[index]
                 if PEAKF > threshold_F1 and PEAKI > threshold_I1:
-                    # Both the filtered and the integrated signal are above their respective
-                    # thresholds. Thus the current peak is classified as a signal peak and
-                    # the running estimates SPKF and SPKI are updated.
+                    # Both the filtered and the integrated signal are above their
+                    # respective thresholds. Thus the current peak is classified as a
+                    # signal peak and the running estimates SPKF and SPKI are updated.
                     SPKF = 0.125 * PEAKF + 0.875 * SPKF
                     SPKI = 0.125 * PEAKI + 0.875 * SPKI
 
@@ -518,8 +520,8 @@ def _thresholding_py(
                 else:
                     noise_peak_found = True
 
-            # The next sample's amplitude is lower, meaning it can't be a peak, so we skip
-            # it. This is why there are two separate if-clauses for this block.
+            # The next sample's amplitude is lower, meaning it can't be a peak, so we
+            # skip it. This is why there are two separate if-clauses for this block.
             index += 1
 
         # Calculating the RR interval and comparing slopes only makes sense if there has
@@ -527,15 +529,15 @@ def _thresholding_py(
         if signal_peak_found and num_peaks_found > 0:
             RR = peak_index - previous_peak_index
 
-            # ------------------------------------------------------------------------------
+            # --------------------------------------------------------------------------
             # T Wave Identification
-            # ------------------------------------------------------------------------------
-            # "When an RR interval is less than 360 ms (it must be greater than the 200 ms
-            # latency), a judgment is made to determine whether the current QRS complex has
-            # been correctly identified or whether it is really a T wave. If the maximal
-            # slope that occurs during this waveform is less than half that of the QRS
-            # waveform that preceded it, it is identified to be a T wave; otherwise, it is
-            # called a QRS complex." (from Pan & Tompkins, 1985)
+            # --------------------------------------------------------------------------
+            # "When an RR interval is less than 360 ms (it must be greater than the 200
+            # ms latency), a judgment is made to determine whether the current QRS
+            # complex has been correctly identified or whether it is really a T wave. If
+            # the maximal slope that occurs during this waveform is less than half that
+            # of the QRS waveform that preceded it, it is identified to be a T wave;
+            # otherwise, it is called a QRS complex." (from Pan & Tompkins, 1985)
             if RR < T_WAVE_WINDOW:
                 reverse_index = peak_index
                 max_slope_in_this_peak = -1
@@ -565,9 +567,9 @@ def _thresholding_py(
                     noise_peak_found = True
 
         if signal_peak_found:
-            # What we know so far: we are at a local maximum, both thresholds are exceeded
-            # and it is not a T wave. Thus, the current sample can be considered as a
-            # "signal peak" and the adaptive thresholds are updated.
+            # What we know so far: we are at a local maximum, both thresholds are
+            # exceeded and it is not a T wave. Thus, the current sample can be
+            # considered as a "signal peak" and the adaptive thresholds are updated.
             num_peaks_found += 1
             beat_mask[peak_index] = 1
 
@@ -578,23 +580,23 @@ def _thresholding_py(
             if num_peaks_found > 1:
                 RR_intervals[num_peaks_found] = peak_index - previous_peak_index
 
-                # --------------------------------------------------------------------------
+                # ----------------------------------------------------------------------
                 # Learning phase 2
-                # --------------------------------------------------------------------------
+                # ----------------------------------------------------------------------
                 # "Learning phase 2 requires two heartbeats to initialize RR interval
                 # average and RR interval limit values." (from Pan & Tompkins, 1985)
                 if num_peaks_found == 2:
                     RR_low_limit = 0.92 * RR_intervals[num_peaks_found]
                     RR_high_limit = 1.16 * RR_intervals[num_peaks_found]
 
-                # --------------------------------------------------------------------------
+                # ----------------------------------------------------------------------
                 # RR Average 1 / RR Average 2
-                # --------------------------------------------------------------------------
-                # RR Average 2 is the average of the 8 most recent RR intervals which fell
-                # between RR_low_limit and RR_high_limit. In case of a regular heart rate,
-                # this equals RR Average 1 (the average over the 8 most recent RR intervals,
-                # independent of any limits). Therefore, RR Average 1 does not need to be
-                # calculated separately.
+                # ----------------------------------------------------------------------
+                # RR Average 2 is the average of the 8 most recent RR intervals which
+                # fell between RR_low_limit and RR_high_limit. In case of a regular
+                # heart rate, this equals RR Average 1 (the average over the 8 most
+                # recent RR intervals, independent of any limits). Therefore, RR Average
+                # 1 does not need to be calculated separately.
                 RR_sum = 0
                 RR_count = 0
                 irregular = False
@@ -614,9 +616,9 @@ def _thresholding_py(
                 RR_missed_limit = 1.66 * RR_average
 
                 if irregular:
-                    # "For irregular heart rates, the first threshold of each set is reduced
-                    # by half so as to increase the detection sensitivity and to avoid
-                    # missing beats."
+                    # "For irregular heart rates, the first threshold of each set is
+                    # reduced by half so as to increase the detection sensitivity and to
+                    # avoid missing beats."
                     threshold_F1 /= 2
                     threshold_I1 /= 2
 

--- a/src/sleepecg/io/capslpdb.py
+++ b/src/sleepecg/io/capslpdb.py
@@ -222,8 +222,7 @@ def read_capslpdb(
     keep_edfs: bool = False,
     data_dir: str | Path | None = None,
 ) -> Iterator[SleepRecord]:
-    """
-    Lazily read records from [CAPSLPDB](https://physionet.org/content/capslpdb/).
+    """Lazily read records from [CAPSLPDB](https://physionet.org/content/capslpdb/).
 
     Each record consists of an EDF file containing polysomnography signals and a text
     file containing sleep-stage annotations. Sleep stages are aligned to complete
@@ -241,8 +240,8 @@ def read_capslpdb(
         If `True`, search for local files only instead of downloading from PhysioNet, by
         default `False`.
     keep_edfs : bool, optional
-        If `False`, remove EDF files downloaded for heartbeat detection after processing,
-        by default `False`.
+        If `False`, remove EDF files downloaded for heartbeat detection after
+        processing, by default `False`.
     data_dir : str | pathlib.Path, optional
         Directory where all datasets are stored. If `None` (default), the value will be
         taken from the configuration.
@@ -334,8 +333,8 @@ def read_capslpdb(
             ecg_data = _get_capslpdb_ecg(edf)
             if ecg_data is None:
                 warnings.warn(
-                    f"Skipping {record_id} because its EDF does not contain a supported "
-                    "ECG channel.",
+                    f"Skipping {record_id} because its EDF does not contain a supported"
+                    " ECG channel.",
                     RuntimeWarning,
                     stacklevel=2,
                 )

--- a/src/sleepecg/io/ecg_readers.py
+++ b/src/sleepecg/io/ecg_readers.py
@@ -27,8 +27,7 @@ from sleepecg.plot import plot_ecg
 
 @dataclass
 class ECGRecord:
-    """
-    Store a single ECG record.
+    """Store a single ECG record.
 
     Attributes
     ----------
@@ -51,8 +50,7 @@ class ECGRecord:
     id: str | None = None
 
     def export(self, filename: str | Path) -> None:
-        """
-        Export ECG record to CSV.
+        """Export ECG record to CSV.
 
         Parameters
         ----------
@@ -62,14 +60,14 @@ class ECGRecord:
         export_ecg_record(self, filename)
 
     def plot(self, **kwargs: np.ndarray) -> tuple[Figure, Axes]:
-        """
-        Plot ECG time series with optional markers.
+        """Plot ECG time series with optional markers.
 
         Parameters
         ----------
         **kwargs : np.ndarray
-            Positions of annotations (i.e. heartbeats) in samples. If more than one marker
-            sequence is given, the keywords will be used as labels in the plot legend.
+            Positions of annotations (i.e. heartbeats) in samples. If more than one
+            marker sequence is given, the keywords will be used as labels in the plot
+            legend.
 
         Returns
         -------
@@ -84,8 +82,7 @@ class ECGRecord:
 
 
 def export_ecg_record(record: ECGRecord, filename: str | Path) -> None:
-    """
-    Export ECG record to CSV.
+    """Export ECG record to CSV.
 
     Parameters
     ----------
@@ -113,8 +110,7 @@ def read_ltdb(
     offline: bool = False,
     data_dir: str | Path | None = None,
 ) -> Iterator[ECGRecord]:
-    """
-    Lazily read records from [LTDB](https://physionet.org/content/ltdb/).
+    """Lazily read records from [LTDB](https://physionet.org/content/ltdb/).
 
     Parameters
     ----------
@@ -144,8 +140,7 @@ def read_mitdb(
     offline: bool = False,
     data_dir: str | Path | None = None,
 ) -> Iterator[ECGRecord]:
-    """
-    Lazily read records from [MITDB](https://physionet.org/content/mitdb/).
+    """Lazily read records from [MITDB](https://physionet.org/content/mitdb/).
 
     Parameters
     ----------
@@ -176,8 +171,7 @@ def _read_mitbih(
     offline: bool,
     data_dir: str | Path,
 ) -> Iterator[ECGRecord]:
-    """
-    Lazily reads records from MIT-BIH datasets (e.g. MITDB, LTDB).
+    """Lazily reads records from MIT-BIH datasets (e.g. MITDB, LTDB).
 
     Required files are downloaded if not present in `<data_dir>/<db_slug>`.
 
@@ -241,8 +235,7 @@ def read_gudb(
     offline: bool = False,
     data_dir: str | Path | None = None,
 ) -> Iterator[ECGRecord]:
-    """
-    Lazily read records from [GUDB](https://berndporr.github.io/ECG-GUDB/).
+    """Lazily read records from [GUDB](https://berndporr.github.io/ECG-GUDB/).
 
     Required files are downloaded if not present in `'<data_dir>/gudb'`.
 
@@ -293,7 +286,7 @@ def read_gudb(
                     ("chest", "II", "III"),
                     np.loadtxt(
                         db_dir / experiment_subdir / "ECG.tsv",
-                        delimiter=" ",  # space-separated (contrary to what .tsv suggests)
+                        delimiter=" ",  # space-separated
                         usecols=(0, 1, 2),
                         unpack=True,
                     ),

--- a/src/sleepecg/io/gudb.py
+++ b/src/sleepecg/io/gudb.py
@@ -370,12 +370,11 @@ _GUDB_MD5 = {
 
 
 def _generate_gudb_md5(data_dir: str | Path | None = None) -> dict[str, str]:
-    """
-    Compute checksums for files in GUDB.
+    """Compute checksums for files in GUDB.
 
-    This function can be used to compute the checksums from scratch if the data is already
-    available locally. The global `_GUDB_MD5` dictionary should be equal to the return value
-    of this function, so usually it is not necessary to run this function.
+    This function can be used to compute the checksums from scratch if the data is
+    already available locally. The global `_GUDB_MD5` dictionary should be equal to the
+    return value of this function, so usually it is not necessary to run this function.
 
     Parameters
     ----------

--- a/src/sleepecg/io/nsrr.py
+++ b/src/sleepecg/io/nsrr.py
@@ -20,8 +20,7 @@ _nsrr_token = None
 
 
 def set_nsrr_token(token: str) -> None:
-    """
-    Set and verify the [NSRR](https://sleepdata.org) download token.
+    """Set and verify the [NSRR](https://sleepdata.org) download token.
 
     Implemented according to the
     [NSRR API specs](https://github.com/nsrr/sleepdata.org/wiki/api-v1-account).
@@ -47,8 +46,7 @@ def set_nsrr_token(token: str) -> None:
 
 
 def _get_nsrr_url(db_slug: str) -> str:
-    """
-    Get the download URL for a given NSRR database.
+    """Get the download URL for a given NSRR database.
 
     The download token is a part of the URL, so it needs to be already set.
 
@@ -81,8 +79,7 @@ def _list_nsrr(
     pattern: str = "*",
     shallow: bool = False,
 ) -> list[tuple[str, str]]:
-    """
-    Recursively list filenames and checksums for a dataset.
+    """Recursively list filenames and checksums for a dataset.
 
     Specify a subfolder and/or a filename-pattern to filter results.
 
@@ -96,8 +93,8 @@ def _list_nsrr(
     subfolder : str, optional
         The folder at which to start the search, by default `''` (i.e. the root folder).
     pattern : str, optional
-        Glob-like pattern to select files (only applied to the basename, not the dirname),
-        by default `'*'`.
+        Glob-like pattern to select files (only applied to the basename, not the
+        dirname), by default `'*'`.
     shallow : bool, optional
         If `True`, only search in the given subfolder (i.e. no recursion), by default
         `False`.
@@ -105,8 +102,8 @@ def _list_nsrr(
     Returns
     -------
     list[tuple[str, str]]
-        A list of tuples `(<filename>, <checksum>)`; `<filename>` is the full filename (i.e.
-        dirname and basename) and `<checksum>` the MD5 checksum.
+        A list of tuples `(<filename>, <checksum>)`; `<filename>` is the full filename
+        (i.e. dirname and basename) and `<checksum>` the MD5 checksum.
     """
     api_url = f"https://sleepdata.org/api/v1/datasets/{db_slug}/files.json"
 
@@ -130,11 +127,11 @@ def _download_nsrr_file(
     target_filepath: Path,
     checksum: str,
 ) -> None:
-    """
-    Download a file from `url` to `target_filepath` and verify `checksum`.
+    """Download a file from `url` to `target_filepath` and verify `checksum`.
 
-    This is a wrapper around `sleepecg.io.utils._download_file` to provide a helpful error
-    message in case the currently set token does not grant access to the requested file.
+    This is a wrapper around `sleepecg.io.utils._download_file` to provide a helpful
+    error message in case the currently set token does not grant access to the requested
+    file.
 
     Parameters
     ----------
@@ -148,8 +145,8 @@ def _download_nsrr_file(
     try:
         _download_file(url, target_filepath, checksum, "md5")
     except RuntimeError as error:
-        # If the token is invalid for the requested dataset, the request is redirected to a
-        # files overview page. The response is an HTML-page which doesn't have a
+        # If the token is invalid for the requested dataset, the request is redirected
+        # to a files overview page. The response is an HTML-page which doesn't have a
         # "content-disposition" header.
         response = _get(url, stream=True)
         if "content-disposition" not in response.headers:
@@ -166,11 +163,10 @@ def download_nsrr(
     shallow: bool = False,
     data_dir: str | Path = ".",
 ) -> None:
-    """
-    Recursively download files from [NSRR](https://sleepdata.org).
+    """Recursively download files from [NSRR](https://sleepdata.org).
 
-    Specify a subfolder and/or a filename pattern to filter results. Implemented according
-    to the [NSRR API specs](https://github.com/nsrr/sleepdata.org/wiki/api-v1-datasets).
+    Specify a subfolder and/or a filename pattern to filter results. Implemented
+    according to the [API](https://github.com/nsrr/sleepdata.org/wiki/api-v1-datasets).
 
     Parameters
     ----------
@@ -179,8 +175,8 @@ def download_nsrr(
     subfolder : str, optional
         The folder at which to start the search, by default `''` (i.e. the root folder).
     pattern : str, optional
-        Glob-like pattern to select files (only applied to the basename, not the dirname),
-        by default `'*'`.
+        Glob-like pattern to select files (only applied to the basename, not the
+        dirname), by default `'*'`.
     shallow : bool, optional
         If `True`, only download files in the given subfolder (i.e. no recursion), by
         default `False`.

--- a/src/sleepecg/io/physionet.py
+++ b/src/sleepecg/io/physionet.py
@@ -26,8 +26,7 @@ def _list_physionet(
     db_version: str = "1.0.0",
     pattern: str = "*",
 ) -> list[str]:
-    """
-    List record IDs for a PhysioNet database.
+    """List record IDs for a PhysioNet database.
 
     IDs can be filtered using a glob-like `pattern`.
 
@@ -69,11 +68,10 @@ def download_physionet(
     db_version: str = "1.0.0",
     data_dir: str | Path = ".",
 ) -> None:
-    """
-    Download requested files from PhysioNet.
+    """Download requested files from PhysioNet.
 
-    All files with `extensions` for record IDs in `requested_records` are downloaded from
-    the PhysioNet database `db_slug`.
+    All files with `extensions` for record IDs in `requested_records` are downloaded
+    from the PhysioNet database `db_slug`.
 
     Parameters
     ----------
@@ -110,8 +108,7 @@ def _get_physionet_checksums(
     db_slug: str,
     db_version: str = "1.0.0",
 ) -> dict[str, str]:
-    """
-    Parse PhysioNet checksums into a dictionary.
+    """Parse PhysioNet checksums into a dictionary.
 
     Reads a PhysioNet checksum file and parses it into a dictionary mapping filenames to
     checksums. Tries to download the checksum file if it is not available on disk.

--- a/src/sleepecg/io/sleep_readers.py
+++ b/src/sleepecg/io/sleep_readers.py
@@ -30,10 +30,10 @@ from sleepecg.io.physionet import _list_physionet, download_physionet
 
 
 class SleepStage(IntEnum):
-    """
-    Mapping of AASM sleep stages to integers.
+    """Mapping of AASM sleep stages to integers.
 
-    To facilitate hypnogram plotting, values start with zero and increase with wakefulness.
+    To facilitate hypnogram plotting, values start with zero and increase with
+    wakefulness.
     """
 
     UNDEFINED = 0
@@ -53,8 +53,7 @@ class Gender(IntEnum):
 
 @dataclass
 class SubjectData:
-    """
-    Store data about a single subject.
+    """Store data about a single subject.
 
     Attributes
     ----------
@@ -74,8 +73,7 @@ class SubjectData:
 
 @dataclass
 class SleepRecord:
-    """
-    Store a single sleep record.
+    """Store a single sleep record.
 
     Attributes
     ----------
@@ -93,9 +91,9 @@ class SleepRecord:
     subject_data : SubjectData, optional
         Dataclass containing subject data (such as gender or age), by default `None`.
     activity_counts: np.ndarray, optional
-        One activity-count value per feature-extraction epoch, by default `None`. Activity
-        counts depend on the device and calculation method, so values produced by
-        different methods are not necessarily comparable.
+        One activity-count value per feature-extraction epoch, by default `None`.
+        Activity counts depend on the device and calculation method, so values produced
+        by different methods are not necessarily comparable.
     """
 
     sleep_stages: np.ndarray | None = None
@@ -115,8 +113,7 @@ class _ParseNsrrXmlResult(NamedTuple):
 
 
 def _parse_nsrr_xml(xml_filepath: Path) -> _ParseNsrrXmlResult:
-    """
-    Parse NSRR XML sleep stage annotation file.
+    """Parse NSRR XML sleep stage annotation file.
 
     Parameters
     ----------
@@ -189,13 +186,12 @@ def read_mesa(
     data_dir: str | Path | None = None,
     activity_source: str | None = None,
 ) -> Iterator[SleepRecord]:
-    """
-    Lazily read records from [MESA](https://sleepdata.org/datasets/mesa).
+    """Lazily read records from [MESA](https://sleepdata.org/datasets/mesa).
 
-    Each MESA record consists of an `.edf` file containing raw polysomnography data and an
-    `.xml` file containing annotated events. Since the entire MESA dataset requires about
-    385 GB of disk space, `.edf` files can be deleted after heartbeat times have been
-    extracted. Heartbeat times are cached in an `.npy` file in
+    Each MESA record consists of an `.edf` file containing raw polysomnography data and
+    an `.xml` file containing annotated events. Since the entire MESA dataset requires
+    about 385 GB of disk space, `.edf` files can be deleted after heartbeat times have
+    been extracted. Heartbeat times are cached in an `.npy` file in
     `<data_dir>/mesa/preprocessed/heartbeats`.
 
     Parameters
@@ -204,10 +200,11 @@ def read_mesa(
          Glob-like pattern to select record IDs, by default `'*'`.
     heartbeats_source : {'annotation', 'cached', 'ecg'}, optional
         If `'annotation'` (default), get heartbeat times from
-        `polysomnography/annotations-rpoints/<record_id>-rpoints.csv` (not available for all
-        records). If `'ecg'`, use `sleepecg.detect_heartbeats()` on the ECG contained in
-        `polysomnography/edfs/<record_id>.edf` and cache the result in
-        `preprocessed/heartbeats/<record_id>.npy`. If `'cached'`, get the cached heartbeats.
+        `polysomnography/annotations-rpoints/<record_id>-rpoints.csv` (not available for
+        all records). If `'ecg'`, use `sleepecg.detect_heartbeats()` on the ECG
+        contained in `polysomnography/edfs/<record_id>.edf` and cache the result in
+        `preprocessed/heartbeats/<record_id>.npy`. If `'cached'`, get the cached
+        heartbeats.
     offline : bool, optional
         If `True`, search for local files only instead of using the NSRR API, by default
         `False`.
@@ -218,8 +215,8 @@ def read_mesa(
         taken from the configuration.
     activity_source : {'actigraphy', 'cached', None}, optional
         If `None` (default), actigraphy data will not be downloaded. If `'actigraphy'`,
-        download actigraphy data from MESA dataset. If `'cached'`, get the cached activity
-        counts.
+        download actigraphy data from MESA dataset. If `'cached'`, get the cached
+        activity counts.
 
     Yields
     ------
@@ -390,7 +387,7 @@ def read_mesa(
                 rpoints_filepath,
                 delimiter=",",
                 skiprows=1,
-                usecols=18,  # column 18 ('seconds') contains the annotated heartbeat times
+                usecols=18,
             )
             # for some reason some (39) records have unsorted annotations
             heartbeat_times.sort()
@@ -533,8 +530,7 @@ def read_slpdb(
     offline: bool = False,
     data_dir: str | Path | None = None,
 ) -> Iterator[SleepRecord]:
-    """
-    Lazily read records from [SLPDB](https://physionet.org/content/slpdb).
+    """Lazily read records from [SLPDB](https://physionet.org/content/slpdb).
 
     Required files are downloaded from PhysioNet to `<data_dir>/slpdb`.
 
@@ -620,8 +616,8 @@ def read_slpdb(
             if annotation[0] in STAGE_MAPPING:
                 sleep_stages[sample_time // (30 * fs)] = STAGE_MAPPING[annotation[0]]
 
-        # Age and weight are given in the last line of the header file, which is contained
-        # in record.comments[0] and looks like this:
+        # Age and weight are given in the last line of the header file, which is
+        # contained in record.comments[0] and looks like this:
         # '44 M 89 32-01-89' ('<age> <gender> <weight> <unspecified>')
         # For some records, age/weight is given as 'x'.
         age, _, weight, _ = record.comments[0].split()
@@ -648,13 +644,12 @@ def read_shhs(
     keep_edfs: bool = False,
     data_dir: str | Path | None = None,
 ) -> Iterator[SleepRecord]:
-    """
-    Lazily read records from [SHHS](https://sleepdata.org/datasets/shhs).
+    """Lazily read records from [SHHS](https://sleepdata.org/datasets/shhs).
 
-    Each SHHS record consists of an `.edf` file containing raw polysomnography data and an
-    `.xml` file containing annotated events. Since the entire SHHS dataset requires about
-    356 GB of disk space, `.edf` files can be deleted after heartbeat times have been
-    extracted. Heartbeat times are cached in an `.npy` file in
+    Each SHHS record consists of an `.edf` file containing raw polysomnography data and
+    an `.xml` file containing annotated events. Since the entire SHHS dataset requires
+    about 356 GB of disk space, `.edf` files can be deleted after heartbeat times have
+    been extracted. Heartbeat times are cached in an `.npy` file in
     `<data_dir>/shhs/preprocessed/heartbeats`.
 
     Parameters
@@ -663,11 +658,11 @@ def read_shhs(
          Glob-like pattern to select record IDs, by default `'*'`.
     heartbeats_source : {'annotation', 'cached', 'ecg'}, optional
         If `'annotation'` (default), get heartbeat times from
-        `polysomnography/annotations-rpoints/shhsX/<record_id>-rpoints.csv`
-        (not available for all records). If `'ecg'`, use `sleepecg.detect_heartbeats()` on
+        `polysomnography/annotations-rpoints/shhsX/<record_id>-rpoints.csv` (not
+        available for all records). If `'ecg'`, use `sleepecg.detect_heartbeats()` on
         the ECG contained in `polysomnography/edfs/shhsX/<record_id>.edf` and cache the
-        result in `preprocessed/heartbeats/shhsX/<record_id>.npy`. If `'cached'`, get the
-        cached heartbeats.
+        result in `preprocessed/heartbeats/shhsX/<record_id>.npy`. If `'cached'`, get
+        the cached heartbeats.
     offline : bool, optional
         If `True`, search for local files only instead of using the NSRR API, by default
         `False`.
@@ -803,7 +798,7 @@ def read_shhs(
                 rpoints_filepath,
                 delimiter=",",
                 skiprows=1,
-                usecols=19,  # column 19 ('seconds') contains the annotated heartbeat times
+                usecols=19,
             )
         elif heartbeats_source == "cached":
             if not heartbeats_file.is_file():

--- a/src/sleepecg/io/utils.py
+++ b/src/sleepecg/io/utils.py
@@ -28,8 +28,7 @@ _session.mount("http://", HTTPAdapter(max_retries=_retries))
 
 
 def _get(url: str, **kwargs: Any) -> requests.Response:
-    """
-    Send a GET request with a timeout and automatic retries on transient failures.
+    """Send a GET request with a timeout and automatic retries on transient failures.
 
     Parameters
     ----------
@@ -47,8 +46,7 @@ def _get(url: str, **kwargs: Any) -> requests.Response:
 
 
 def _calculate_checksum(filepath: Path, checksum_type: str) -> str:
-    """
-    Calculate the checksum for a file.
+    """Calculate the checksum for a file.
 
     Parameters
     ----------
@@ -76,11 +74,10 @@ def _download_file(
     checksum_type: str | None = None,
     verbose: bool = False,
 ) -> None:
-    """
-    Download a single file from `url` to `target_filepath`.
+    """Download a single file from `url` to `target_filepath`.
 
-    In case `checksum` and `checksum_type` are provided, the downloaded file is verified.
-    Raises a `RuntimeError` if verification fails.
+    In case `checksum` and `checksum_type` are provided, the downloaded file is
+    verified. Raises a `RuntimeError` if verification fails.
 
     Parameters
     ----------

--- a/src/sleepecg/plot.py
+++ b/src/sleepecg/plot.py
@@ -25,8 +25,7 @@ def plot_ecg(
     title: str | None = None,
     **kwargs: np.ndarray,
 ) -> tuple[Figure, Axes]:
-    """
-    Plot ECG time series with optional markers.
+    """Plot ECG time series with optional markers.
 
     Parameters
     ----------
@@ -61,9 +60,9 @@ def plot_ecg(
 
     >>> plot(ecg, fs, marker1=annotations, marker2=heartbeats)
 
-    The last example will create two annotation series, the first one labeled `marker1` with
-    positions given by `annotations`, and the second one labeled `marker2` with positions
-    given by `heartbeats`.
+    The last example will create two annotation series, the first one labeled `marker1`
+    with positions given by `annotations`, and the second one labeled `marker2` with
+    positions given by `heartbeats`.
     """
     import matplotlib.pyplot as plt
     from matplotlib import colormaps
@@ -108,8 +107,7 @@ def plot_hypnogram(
     merge_annotations: bool = False,
     show_bpm: bool = False,
 ) -> tuple[Figure, list[Axes]]:
-    """
-    Plot a hypnogram for a single record.
+    """Plot a hypnogram for a single record.
 
     Annotated sleep stages are included in the plot if available in `record`. If
     `stages_pred` contains probabilities, they are shown in an additional subplot.
@@ -122,16 +120,16 @@ def plot_hypnogram(
         The predicted stages, either as a 1D array of integers or a 2D array of
         probabilities.
     stages_mode : str
-        Identifier of the grouping mode. Can be any of `'wake-sleep'`, `'wake-rem-nrem'`,
-        `'wake-rem-light-n3'`, or `'wake-rem-n1-n2-n3'`.
+        Identifier of the grouping mode. Can be any of `'wake-sleep'`,
+        `'wake-rem-nrem'`, `'wake-rem-light-n3'`, or `'wake-rem-n1-n2-n3'`.
     stages_pred_duration : int, optional
         Duration of the predicted sleep stages in seconds, by default `30`.
     merge_annotations : bool, optional
         If `True`, merge annotations according to `stages_mode`, otherwise plot original
         annotations. By default `False`.
     show_bpm : bool, optional
-        If `True`, include a subplot of the heart rate in bpm. This can be helpful to find
-        bad signal quality intervals, by default `False`.
+        If `True`, include a subplot of the heart rate in bpm. This can be helpful to
+        find bad signal quality intervals, by default `False`.
 
     Returns
     -------
@@ -238,8 +236,7 @@ def _plot_confusion_matrix(
     confmat: np.ndarray,
     stage_names: list[str],
 ) -> tuple[Figure, Axes]:
-    """
-    Create a labeled plot of a confusion matrix.
+    """Create a labeled plot of a confusion matrix.
 
     Parameters
     ----------

--- a/src/sleepecg/utils.py
+++ b/src/sleepecg/utils.py
@@ -25,11 +25,10 @@ def _parallel(
     *args: Any,
     **kwargs: Any,
 ) -> list[_Returnable]:
-    """
-    Apply a function to each element in an iterable in parallel.
+    """Apply a function to each element in an iterable in parallel.
 
-    This uses joblib for parallelism. If the package is not available, it falls back to a
-    pure Python loop.
+    This uses joblib for parallelism. If the package is not available, it falls back to
+    a pure Python loop.
 
     Parameters
     ----------
@@ -52,8 +51,8 @@ def _parallel(
 
     Warnings
     --------
-    Note that in case the `function` is very simple, the cost for spawning workers will make
-    the parallel execution slower than the standard execution.
+    Note that in case the `function` is very simple, the cost for spawning workers will
+    make the parallel execution slower than the standard execution.
 
     Examples
     --------
@@ -81,8 +80,7 @@ def _parallel(
 
 
 def _time_to_sec(time: datetime.time) -> int:
-    """
-    Convert a `datetime.time` to seconds.
+    """Convert a `datetime.time` to seconds.
 
     `00:00:00` corresponds to `0` and `23:59:59` to `86399`.
 
@@ -101,10 +99,11 @@ def _time_to_sec(time: datetime.time) -> int:
 
 # Classifiers don't always discriminate between all sleep stages defined by the AASM
 # guidelines. This dictionary is used to create a consistent mapping from groups of AASM
-# sleep stages (as defined in `SleepStage`) to integers. `SleepStage.UNDEFINED` is always
-# `0` and the actual stages' values increase with wakefulness, so they map correctly to the
-# y-axis in a hypnogram plot. Gaps between stage values are avoided as non-existing classes
-# in a one-hot encoding leads to issues when calculating class weights and losses.
+# sleep stages (as defined in `SleepStage`) to integers. `SleepStage.UNDEFINED` is
+# always `0` and the actual stages' values increase with wakefulness, so they map
+# correctly to the y-axis in a hypnogram plot. Gaps between stage values are avoided as
+# non-existing classes in a one-hot encoding leads to issues when calculating class
+# weights and losses.
 
 _SLEEP_STAGE_MAPPING = {
     "wake-sleep": {
@@ -142,17 +141,16 @@ _STAGE_INTS = {k: sorted(set(v.values())) for k, v in _SLEEP_STAGE_MAPPING.items
 
 
 def _merge_sleep_stages(stages: list[np.ndarray], stages_mode: str) -> list[np.ndarray]:
-    """
-    Merge sleep stage labels into groups.
+    """Merge sleep stage labels into groups.
 
     Parameters
     ----------
     stages : list[np.ndarray]
-        A list of 1D arrays containing AASM sleep stages as defined by `SleepStage`, e.g. as
-        returned by `extract_features()`.
+        A list of 1D arrays containing AASM sleep stages as defined by `SleepStage`,
+        e.g. as returned by `extract_features()`.
     stages_mode : str
-        Identifier of the grouping mode. Can be any of `'wake-sleep'`, `'wake-rem-nrem'`,
-        `'wake-rem-light-n3'`, `'wake-rem-n1-n2-n3'`.
+        Identifier of the grouping mode. Can be any of `'wake-sleep'`,
+        `'wake-rem-nrem'`, `'wake-rem-light-n3'`, `'wake-rem-n1-n2-n3'`.
 
     Returns
     -------
@@ -175,8 +173,7 @@ def _merge_sleep_stages(stages: list[np.ndarray], stages_mode: str) -> list[np.n
 
 
 def get_toy_ecg() -> tuple[np.ndarray, int]:
-    """
-    Load a 5 minute long electrocardigram sampled at 360 Hz.
+    """Load a 5 minute long electrocardigram sampled at 360 Hz.
 
     Data taken from scipy.datasets.electrocardiogram:
     https://docs.scipy.org/doc/scipy/reference/generated/scipy.datasets.electrocardiogram.html

--- a/tests/test_feature_extraction.py
+++ b/tests/test_feature_extraction.py
@@ -20,12 +20,11 @@ from sleepecg.io.sleep_readers import SleepRecord, SubjectData
 
 
 def test_feature_ids():
-    """
-    Compare length of feature id lists with shape of feature matrices.
+    """Compare length of feature id lists with shape of feature matrices.
 
-    If this fails, make sure the identifiers in `feature_extraction._FEATURE_GROUPS` match
-    the calculated features in the relevant function. Note that the test only compares
-    lengths, so the order might still be incorrect.
+    If this fails, make sure the identifiers in `feature_extraction._FEATURE_GROUPS`
+    match the calculated features in the relevant function. Note that the test only
+    compares lengths, so the order might still be incorrect.
     """
     heartbeat_times = np.cumsum(np.random.uniform(0.5, 1.5, 60 * 60))
     sleep_stages = np.random.randint(1, 6, int(max(heartbeat_times)) // 30)

--- a/tests/test_heartbeats.py
+++ b/tests/test_heartbeats.py
@@ -30,7 +30,7 @@ def mitdb_234_MLII():
     """Fetch record for detector tests."""
     pytest.importorskip("wfdb")
     # CI caches downloaded PhysioNet files across runs in this directory, see
-    # .github/workflows/cibuildwheel.yml; falls back to the configured default otherwise.
+    # .github/workflows/cibuildwheel.yml; falls back to the configured default otherwise
     data_dir = os.environ.get("SLEEPECG_TEST_DATA_DIR")
     return next(read_mitdb(records_pattern="234", data_dir=data_dir))
 

--- a/tests/test_sleep_readers.py
+++ b/tests/test_sleep_readers.py
@@ -196,7 +196,7 @@ def _create_dummy_shhs(data_dir: str, durations: list[float], random_state: int 
 
 
 def test_read_mesa(tmp_path):
-    """Basic sanity checks for records read via read_mesa."""
+    """Sanity checks for records read via read_mesa."""
     durations = [0.1, 0.2]  # hours
     valid_stages = {int(s) for s in SleepStage}
 
@@ -211,7 +211,7 @@ def test_read_mesa(tmp_path):
 
 
 def test_read_mesa_actigraphy(tmp_path):
-    """Basic sanity checks for records read via read_mesa including actigraphy."""
+    """Sanity checks for records read via read_mesa including actigraphy."""
     durations = [0.1, 0.2]  # hours
     valid_stages = {int(s) for s in SleepStage}
 
@@ -239,7 +239,7 @@ def test_read_mesa_actigraphy(tmp_path):
 
 
 def test_read_mesa_actigraphy_cached(tmp_path):
-    """Basic sanity checks for records read via read_mesa including cached actigraphy."""
+    """Sanity checks for records read via read_mesa including cached actigraphy."""
     durations = [0.1, 0.2]  # hours
     valid_stages = {int(s) for s in SleepStage}
 
@@ -262,7 +262,7 @@ def test_read_mesa_actigraphy_cached(tmp_path):
 
 
 def test_read_shhs(tmp_path):
-    """Basic sanity checks for records read via read_shhs."""
+    """Sanity checks for records read via read_shhs."""
     durations = [0.1, 0.2]  # hours
     valid_stages = {int(s) for s in SleepStage}
 
@@ -280,7 +280,7 @@ def test_read_slpdb():
     """Basic test for read_slpdb."""
     pytest.importorskip("wfdb")
     # CI caches downloaded PhysioNet files across runs in this directory, see
-    # .github/workflows/cibuildwheel.yml; falls back to the configured default otherwise.
+    # .github/workflows/cibuildwheel.yml; falls back to the configured default otherwise
     data_dir = os.environ.get("SLEEPECG_TEST_DATA_DIR")
     rec = next(read_slpdb(records_pattern="slp01a", data_dir=data_dir))
     assert rec.sleep_stages.shape == (240,)


### PR DESCRIPTION
Rule E501 needed to be enabled explicitly, and the following seciton is necessary to enforce line length in docstrings:

```
[tool.ruff.lint.pycodestyle]
max-doc-length = 88
```