### PR TITLE
Optimize pyproject dependency groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,12 +42,10 @@ cibw = [  # cibuildwheel uses this for running the test suite
     "wfdb >= 4.2.0",
 ]
 full = [  # complete package functionality
-    "edfio >= 0.4.4",
+    "sleepecg[cibw]",
     "joblib >= 1.4.2",
     "matplotlib >= 3.9.2",
-    "numba >= 0.61.0",
-    "tensorflow >= 2.17.0; python_version < '3.13'",
-    "wfdb >= 4.2.0",
+    "tensorflow >= 2.21.0; python_version < '3.14'",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -1072,8 +1072,8 @@ name = "h5py"
 version = "3.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5d/57/dfb3c5c3f1bf5f5ef2e59a22dec4ff1f3d7408b55bfcefcfb0ea69ef21c6/h5py-3.14.0.tar.gz", hash = "sha256:2372116b2e0d5d3e5e705b7f663f7c8d96fa79a4052d250484ef91d24d6a08f4", size = 424323, upload-time = "2025-06-06T14:06:15.01Z" }
 wheels = [
@@ -1165,8 +1165,11 @@ name = "keras"
 version = "3.15.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
@@ -1758,8 +1761,8 @@ name = "ml-dtypes"
 version = "0.5.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/4a/c27b42ed9b1c7d13d9ba8b6905dece787d6259152f2309338aed29b2447b/ml_dtypes-0.5.4.tar.gz", hash = "sha256:8ab06a50fb9bf9666dd0fe5dfb4676fa2b0ac0f31ecff72a6c3af8e22c063453", size = 692314, upload-time = "2025-11-17T22:32:31.031Z" }
 wheels = [
@@ -3126,7 +3129,7 @@ full = [
     { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "matplotlib", version = "3.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "numba" },
-    { name = "tensorflow", marker = "python_full_version < '3.13'" },
+    { name = "tensorflow", marker = "python_full_version < '3.14'" },
     { name = "wfdb" },
 ]
 
@@ -3157,19 +3160,17 @@ lint = [
 [package.metadata]
 requires-dist = [
     { name = "edfio", marker = "extra == 'cibw'", specifier = ">=0.4.4" },
-    { name = "edfio", marker = "extra == 'full'", specifier = ">=0.4.4" },
     { name = "joblib", marker = "extra == 'full'", specifier = ">=1.4.2" },
     { name = "matplotlib", marker = "extra == 'full'", specifier = ">=3.9.2" },
     { name = "numba", marker = "extra == 'cibw'", specifier = ">=0.61.0" },
-    { name = "numba", marker = "extra == 'full'", specifier = ">=0.61.0" },
     { name = "numpy", specifier = ">=1.26.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },
     { name = "requests", specifier = ">=2.32.3" },
     { name = "scipy", specifier = ">=1.13.0" },
-    { name = "tensorflow", marker = "python_full_version < '3.13' and extra == 'full'", specifier = ">=2.17.0" },
+    { name = "sleepecg", extras = ["cibw"], marker = "extra == 'full'" },
+    { name = "tensorflow", marker = "python_full_version < '3.14' and extra == 'full'", specifier = ">=2.21.0" },
     { name = "tqdm", specifier = ">=4.66.0" },
     { name = "wfdb", marker = "extra == 'cibw'", specifier = ">=4.2.0" },
-    { name = "wfdb", marker = "extra == 'full'", specifier = ">=4.2.0" },
 ]
 provides-extras = ["cibw", "full"]
 
@@ -3231,12 +3232,12 @@ dependencies = [
     { name = "google-pasta" },
     { name = "grpcio" },
     { name = "h5py" },
-    { name = "keras", version = "3.12.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
-    { name = "keras", version = "3.15.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "keras", version = "3.12.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
+    { name = "keras", version = "3.15.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
     { name = "libclang" },
     { name = "ml-dtypes" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
     { name = "opt-einsum" },
     { name = "packaging" },
     { name = "protobuf" },


### PR DESCRIPTION
Include cibw in full; also bump tensorflow (it now has wheels for Python 3.13).